### PR TITLE
Adding a Dockerfile and default config for running it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.redhat.io/rhel8/go-toolset:1.13 AS builder
+
+COPY . .
+
+USER 0
+
+# build the aggregator
+RUN umask 0022 && \
+    make build && \
+    chmod a+x insights-results-aggregator-mock
+
+FROM registry.redhat.io/ubi8-minimal
+
+COPY --from=builder /opt/app-root/src/insights-results-aggregator-mock .
+COPY --from=builder /opt/app-root/src/config_container.toml ./config.toml
+COPY --from=builder /opt/app-root/src/openapi.json .
+COPY --from=builder /opt/app-root/src/groups_config.yaml .
+COPY --from=builder /opt/app-root/src/data ./data
+
+USER 1001
+
+CMD ["/insights-results-aggregator-mock"]

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -105,7 +105,7 @@ func LoadConfiguration(defaultConfigFile string) (ConfigStruct, error) {
 
 	// override config from env if there's variable in env
 
-	const envPrefix = "INSIGHTS_CONTENT_SERVICE_"
+	const envPrefix = "INSIGHTS_RESULTS_AGGREGATOR_MOCK_"
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix(envPrefix)

--- a/config_container.toml
+++ b/config_container.toml
@@ -1,0 +1,10 @@
+[server]
+address = ":8080"
+api_prefix = "/api/v1/"
+api_spec_file = "/openapi.json"
+
+[groups]
+path = "/groups_config.yaml"
+
+[paths]
+mock_data = "/data"


### PR DESCRIPTION
Adding a `Dockerfile` to generate a container image to create the image.
Adding a configuration file suitable for directly use the container generated by the `Dockerfile`
Minor fix on the `conf` package in order to use environment variables to overwrite the file configuration