### PR TITLE
Ack endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ rest-api-tests
 rules-content
 issue.py
 *.csv
+mock

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Mock service mimicking Insights Results Aggregator
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/RedHatInsights/insights-results-aggregator-mock)
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/RedHatInsights/insights-results-aggregator-mock/blob/master/LICENSE)
 
+
 <!-- vim-markdown-toc GFM -->
 
 * [Description](#description)
@@ -33,8 +34,23 @@ Mock service mimicking Insights Results Aggregator
     * [List of clusters that return improper results and/or failure](#list-of-clusters-that-return-improper-results-andor-failure)
 * [List of clusters hitting specified rule](#list-of-clusters-hitting-specified-rule)
     * [An example of response:](#an-example-of-response)
+* [Endpoint to ack rule](#endpoint-to-ack-rule)
+    * [List of acked rules](#list-of-acked-rules)
+    * [Ack rule with specified justification](#ack-rule-with-specified-justification)
+        * [Ack new rule](#ack-new-rule)
+        * [Ack existing rule](#ack-existing-rule)
+    * [Ack rule](#ack-rule)
+        * [Ack new rule](#ack-new-rule-1)
+        * [Ack existing rule](#ack-existing-rule-1)
+    * [Update rule](#update-rule)
+        * [Update existing rule](#update-existing-rule)
+        * [Update non existing rule](#update-non-existing-rule)
+    * [Delete rule](#delete-rule)
+        * [Delete existing rule](#delete-existing-rule)
+        * [Delete nonexisting rule](#delete-nonexisting-rule)
 
 <!-- vim-markdown-toc -->
+
 
 ## Description
 
@@ -350,4 +366,271 @@ curl 'localhost:8080/api/v1/rule/ccx_rules_ocp.external.rules.nodes_requirements
                 "ee7d2bf4-8933-4a3a-8634-3328fe806e08"
         ]
 }
+```
+
+## Endpoint to ack rule
+
+
+
+### List of acked rules
+
+List acks from this account where the rule is active. Will return an empty list if this account has no acks.
+
+Request to the service:
+
+```
+curl localhost:8080/api/v1/ack
+```
+
+Response from the service:
+
+```
+{
+        "meta": {
+                "count": 5
+        },
+        "data": [
+                {
+                        "rule": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report|NODE_KUBELET_VERSION",
+                        "justification": "Justification3",
+                        "created_by": "tester3",
+                        "created_at": "2021-09-04T17:11:35.130Z",
+                        "updated_at": "2021-09-04T17:11:35.130Z"
+                },
+                {
+                        "rule": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                        "justification": "Justification4",
+                        "created_by": "tester4",
+                        "created_at": "2021-09-04T17:11:35.130Z",
+                        "updated_at": "2021-09-04T17:11:35.130Z"
+                },
+                {
+                        "rule": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR",
+                        "justification": "Justification5",
+                        "created_by": "tester5",
+                        "created_at": "2021-09-04T17:11:35.130Z",
+                        "updated_at": "2021-09-04T17:11:35.130Z"
+                },
+                {
+                        "rule": "ccx_rules_ocp.external.rules.nodes_requirements_check.report|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                        "justification": "Justification1",
+                        "created_by": "tester1",
+                        "created_at": "2021-09-04T17:11:35.130Z",
+                        "updated_at": "2021-09-04T17:11:35.130Z"
+                },
+                {
+                        "rule": "ccx_rules_ocp.external.bug_rules.bug_1766907.report|BUGZILLA_BUG_1766907",
+                        "justification": "Justification2",
+                        "created_by": "tester2",
+                        "created_at": "2021-09-04T17:11:35.130Z",
+                        "updated_at": "2021-09-04T17:11:35.130Z"
+                }
+        ]
+}
+```
+
+### Ack rule with specified justification
+
+Acknowledges (and therefore hides) a rule from view in an account. If there's
+already an acknowledgement of this rule by this account, then return that.
+Otherwise, a new ack is created.
+
+#### Ack new rule
+
+Request to the service:
+
+```
+curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"foo|bar", "justification":"xyzzy"}' "localhost:8080/api/v1/ack"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 201 Created
+< Content-Type: application/json; charset=utf-8
+< Date: Sun, 05 Sep 2021 14:29:33 GMT
+< Content-Length: 168
+< 
+{
+        "rule": "foo|bar",
+        "justification": "xyzzy",
+        "created_by": "onlineTester",
+        "created_at": "2021-09-05T16:29:33+02:00",
+        "updated_at": "2021-09-05T16:29:33+02:00"
+}
+```
+
+#### Ack existing rule
+
+Request to the service:
+
+```
+curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"existing|rule", "justification":"xyzzy"}' "localhost:8080/api/v1/ack"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 200 OK
+< Content-Type: application/json; charset=utf-8
+< Date: Sun, 05 Sep 2021 14:35:51 GMT
+< Content-Length: 168
+< 
+{
+        "rule": "foo|bar",
+        "justification": "xyzzy",
+        "created_by": "onlineTester",
+        "created_at": "2021-09-05T16:35:25+02:00",
+        "updated_at": "2021-09-05T16:35:25+02:00"
+}
+
+```
+
+
+
+### Ack rule
+
+Acks acknowledge (and therefore hide) a rule from view in an account. This view
+handles listing, retrieving, creating and deleting acks. Acks are created and
+deleted by Insights rule ID, not by their own ack ID.
+
+#### Ack new rule
+
+Request to the service:
+
+```
+curl -v "localhost:8080/api/v1/ack/new|rule"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 200 OK
+< Content-Type: application/json; charset=utf-8
+< Date: Sat, 04 Sep 2021 18:46:20 GMT
+< Content-Length: 165
+< 
+{
+        "rule": "new|rule",
+        "justification": "?",
+        "created_by": "onlineTester",
+        "created_at": "2021-09-04T20:46:20+02:00",
+        "updated_at": "2021-09-04T20:46:20+02:00"
+}
+```
+
+#### Ack existing rule
+
+Request to the service:
+
+```
+curl -v "localhost:8080/api/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 200 OK
+< Content-Type: application/json; charset=utf-8
+< Date: Sat, 04 Sep 2021 18:32:58 GMT
+< Content-Length: 260
+< 
+{
+        "rule": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR",
+        "justification": "Justification5",
+        "created_by": "onlineTester",
+        "created_at": "2021-09-04T17:11:35.130Z",
+        "updated_at": "2021-09-04T20:32:58+02:00"
+
+```
+
+Please note that just `updated_at` attribute is changed in this situation.
+
+### Update rule
+
+#### Update existing rule
+
+Request to the service:
+
+```
+curl -v-X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/v1/ack/existing|rule"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 200 OK
+< Date: Sun, 05 Sep 2021 05:47:46 GMT
+< Content-Length: 169
+< Content-Type: text/plain; charset=utf-8
+< 
+{
+        "rule": "existing|rule",
+        "justification": "xyzzy",
+        "created_by": "onlineTester",
+        "created_at": "2021-09-05T07:45:00+02:00",
+        "updated_at": "2021-09-05T07:47:46+02:00"
+}
+```
+
+#### Update non existing rule
+
+Update an acknowledgement for a rule, by rule ID. A new justification can be
+supplied. The username is taken from the authenticated request. The updated ack
+is returned.
+
+Request to the service:
+
+```
+curl -v -X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/v1/ack/new|rule"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 404 Not Found
+< Content-Type: text/plain; charset=utf-8
+< X-Content-Type-Options: nosniff
+< Date: Sun, 05 Sep 2021 06:13:27 GMT
+< Content-Length: 51
+< 
+rule not found -> justification can not be changed
+```
+
+### Delete rule
+
+Delete an acknowledgement for a rule, by its rule ID. If the ack existed, it is
+deleted and a 204 is returned. Otherwise, a 404 is returned.
+
+#### Delete existing rule
+
+Request to the service:
+
+```
+curl-v -X DELETE "localhost:8080/api/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 204 No Content
+< Date: Sat, 04 Sep 2021 17:44:32 GMT
+< 
+```
+
+#### Delete nonexisting rule
+
+Request to the service:
+
+```
+curl-v -X DELETE "localhost:8080/api/v1/ack/foobar|foobar"
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 404 Not Found
+< Date: Sat, 04 Sep 2021 17:44:35 GMT
+< Content-Length: 0
+< 
 ```

--- a/server/acks_data.go
+++ b/server/acks_data.go
@@ -1,0 +1,75 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+// Already acked rules to be used by client code.
+import "github.com/RedHatInsights/insights-results-aggregator-mock/types"
+
+// I don't like too long string literals in code
+const (
+	rule1 = "ccx_rules_ocp.external.rules.nodes_requirements_check.report|NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+	rule2 = "ccx_rules_ocp.external.bug_rules.bug_1766907.report|BUGZILLA_BUG_1766907"
+	rule3 = "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report|NODE_KUBELET_VERSION"
+	rule4 = "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report|SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+	rule5 = "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
+)
+
+// the only data structure we have to deal with
+var acks map[types.RuleSelector]types.Acknowledge = make(map[types.RuleSelector]types.Acknowledge)
+
+// initialize the acks data structure
+func init() {
+	acks[rule1] = types.Acknowledge{
+		Acknowledged:  true,
+		Rule:          rule1,
+		Justification: "Justification1",
+		CreatedBy:     "tester1",
+		CreatedAt:     "2021-09-04T17:11:35.130Z",
+		UpdatedAt:     "2021-09-04T17:11:35.130Z"}
+
+	acks[rule2] = types.Acknowledge{
+		Acknowledged:  true,
+		Rule:          rule2,
+		Justification: "Justification2",
+		CreatedBy:     "tester2",
+		CreatedAt:     "2021-09-04T17:11:35.130Z",
+		UpdatedAt:     "2021-09-04T17:11:35.130Z"}
+
+	acks[rule3] = types.Acknowledge{
+		Acknowledged:  true,
+		Rule:          rule3,
+		Justification: "Justification3",
+		CreatedBy:     "tester3",
+		CreatedAt:     "2021-09-04T17:11:35.130Z",
+		UpdatedAt:     "2021-09-04T17:11:35.130Z"}
+
+	acks[rule4] = types.Acknowledge{
+		Acknowledged:  true,
+		Rule:          rule4,
+		Justification: "Justification4",
+		CreatedBy:     "tester4",
+		CreatedAt:     "2021-09-04T17:11:35.130Z",
+		UpdatedAt:     "2021-09-04T17:11:35.130Z"}
+
+	acks[rule5] = types.Acknowledge{
+		Acknowledged:  true,
+		Rule:          rule5,
+		Justification: "Justification5",
+		CreatedBy:     "tester5",
+		CreatedAt:     "2021-09-04T17:11:35.130Z",
+		UpdatedAt:     "2021-09-04T17:11:35.130Z"}
+}

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -1,0 +1,295 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/RedHatInsights/insights-results-aggregator-mock/types"
+)
+
+// HTTP response-related constants
+const (
+	contentType = "Content-Type"
+	appJSON     = "application/json; charset=utf-8"
+)
+
+// other constants
+const (
+	defaultUserName      = "onlineTester"
+	defaultJustification = "?"
+)
+
+// method readAckList list acks from this account where the rule is active.
+// Will return an empty list if this account has no acks.
+//
+// Response format should look like:
+// {
+//   "meta": {
+//     "count": 0
+//   },
+//   "links": {
+//     "first": "string",
+//     "previous": "string",
+//     "next": "string",
+//     "last": "string"
+//   },
+//   "data": [
+//     {
+//       "rule": "string",
+//       "justification": "string",
+//       "created_by": "string",
+//       "created_at": "2021-09-04T17:11:35.130Z",
+//       "updated_at": "2021-09-04T17:11:35.130Z"
+//     }
+//   ]
+// }
+//
+// Please note that for the sake of simplicity we don't use links section as
+// pagination is not supported ATM.
+func (server *HTTPServer) readAckList(writer http.ResponseWriter, request *http.Request) {
+	// set the response header
+	writer.Header().Set(contentType, appJSON)
+
+	var responseBody types.AcknowledgementsResponse
+
+	// fill-in metadata part of response body
+	responseBody.Metadata.Count = len(acks)
+
+	// fill-in data part of response body
+	responseBody.Data = make([]types.Acknowledge, len(acks))
+
+	i := 0
+	for _, ack := range acks {
+		responseBody.Data[i] = ack
+		i++
+	}
+
+	// serialize the above data structure into JSON format
+	bytes, err := json.MarshalIndent(responseBody, "", "\t")
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+		return
+	}
+
+	// and send the serialized structure to client
+	_, err = writer.Write(bytes)
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}
+
+// method acknowledgePost acknowledges (and therefore hides) a rule from view
+// in an account. If there's already an acknowledgement of this rule by this
+// account, then return that. Otherwise, a new ack is created.
+//
+// An example request:
+//
+// {
+//   "rule_id": "string",
+//   "justification": "string"
+// }
+//
+// An example response:
+//
+// {
+//   "rule": "string",
+//   "justification": "string",  <- can not be set by this call!!!
+//   "created_by": "string",
+//   "created_at": "2021-09-04T17:52:48.976Z",
+//   "updated_at": "2021-09-04T17:52:48.976Z"
+// }
+func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set(contentType, appJSON)
+
+	// try to read request body
+	var parameters types.AcknowledgementRuleSelectorJustification
+	err := json.NewDecoder(request.Body).Decode(&parameters)
+
+	if err != nil {
+		log.Error().Err(err).Msg("wrong payload provided by client")
+		// return 400
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// we seem to have proper data
+	log.Info().
+		Str("rule", string(parameters.RuleSelector)).
+		Str("value", parameters.Value).
+		Msg("Proper payload provided")
+
+	// check if rule selector has the proper format
+	_, _, err = parseRuleSelector(parameters.RuleSelector)
+	if err != nil {
+		log.Error().Err(err).Msg("improper rule selector format")
+		// return 400
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// try to find the rule in map of active rules
+	_, found := acks[parameters.RuleSelector]
+	if !found {
+		// rule not found -> add a new one
+		addNewRule(parameters.RuleSelector, parameters.Value, defaultUserName)
+		// update HTTP status code accordingly
+		writer.WriteHeader(http.StatusCreated)
+	}
+
+	// return existing rule or the new one (if created)
+	returnRuleAckToClient(writer, acks[parameters.RuleSelector])
+}
+
+// method getAcknowledge acknowledges (and therefore hides) a rule from view in
+// an account. This view handles listing, retrieving, creating and deleting
+// acks. Acks are created and deleted by Insights rule ID, not by their own ack
+// ID.
+//
+// An example response:
+//
+// {
+//   "rule": "string",
+//   "justification": "string",  <- can not be set by this call!!!
+//   "created_by": "string",
+//   "created_at": "2021-09-04T17:52:48.976Z",
+//   "updated_at": "2021-09-04T17:52:48.976Z"
+// }
+//
+// Please note that it is impossible to set "justification" field into any
+// value that makes sense!
+func (server *HTTPServer) getAcknowledge(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set(contentType, appJSON)
+
+	// read the selector
+	ruleSelector, err := readRuleSelector(writer, request)
+
+	// check for missing/improper selector
+	if err != nil {
+		handleImproperSelector(writer, err)
+		// everything has been handled already
+		return
+	}
+
+	// try to find the rule in map of active rules
+	_, found := acks[ruleSelector]
+	if !found {
+		// rule not found -> add a new one
+		addNewRule(ruleSelector, defaultJustification, defaultUserName)
+	} else {
+		// rule has been found -> just update it
+		updateRuleUpdatedAt(ruleSelector)
+	}
+
+	returnRuleAckToClient(writer, acks[ruleSelector])
+}
+
+// method updateAcknowledge updates an acknowledgement for a rule, by rule ID.
+// A new justification can be supplied. The username is taken from the
+// authenticated request. The updated ack is returned.
+//
+// An example of request:
+//
+// {
+//    "justification": "string"
+// }
+//
+// An example response:
+//
+// {
+//   "rule": "string",
+//   "justification": "string",
+//   "created_by": "string",
+//   "created_at": "2021-09-04T17:52:48.976Z",
+//   "updated_at": "2021-09-04T17:52:48.976Z"
+// }
+//
+// Additionally, if rule is not found, 404 is returned (not mentioned in
+// original REST API specification).
+func (server *HTTPServer) updateAcknowledge(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set(contentType, appJSON)
+
+	// read the selector
+	ruleSelector, err := readRuleSelector(writer, request)
+
+	// check for missing/improper selector
+	if err != nil {
+		handleImproperSelector(writer, err)
+		// everything has been handled already
+		return
+	}
+
+	// try to find the rule in map of active rules
+	_, found := acks[ruleSelector]
+	if !found {
+		handleMissingRule(writer, string(ruleSelector))
+		// everything has been handled already
+		return
+	}
+
+	// try to read request body
+	var justification types.AcknowledgementJustification
+	err = json.NewDecoder(request.Body).Decode(&justification)
+
+	if err != nil {
+		log.Error().Err(err).Msg("justification provided by client")
+		// return 400
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	log.Info().
+		Str("value", justification.Value).
+		Msg("Justification provided")
+
+	// update existing rule
+	updateRuleJustification(ruleSelector, justification)
+
+	returnRuleAckToClient(writer, acks[ruleSelector])
+}
+
+// method deleteAcknowledge deletes an acknowledgement for a rule, by its rule
+// ID. If the ack existed, it is deleted and a 204 is returned. Otherwise, a
+// 404 is returned.
+func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request *http.Request) {
+	// read the selector
+	ruleSelector, err := readRuleSelector(writer, request)
+
+	// check for missing/improper selector
+	if err != nil {
+		handleImproperSelector(writer, err)
+		// everything has been handled already
+		return
+	}
+
+	// try to find the rule in map of active rules
+	_, found := acks[ruleSelector]
+	if !found {
+		// return 404
+		writer.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// rule has been acknowledget -> we can delete it
+	delete(acks, ruleSelector)
+
+	// return 204 -> rule ack has been deleted
+	writer.WriteHeader(http.StatusNoContent)
+}

--- a/server/acks_utils.go
+++ b/server/acks_utils.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+// Helper functions to be called from request handlers defined in the source
+// file acks_handlers.go.
+
+import (
+	"errors"
+	"time"
+
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/RedHatInsights/insights-results-aggregator-mock/types"
+)
+
+// Log error messages
+const (
+	unableToReadRuleSelector = "Unable to read rule selector"
+)
+
+// formattedNow function returns current time formatted according to RFC3339
+func formattedNow() string {
+	return time.Now().Format(time.RFC3339)
+}
+
+// handleImproperSelector function handles situation when rule selector can not
+// be read from client request. HTTP code 400 Bad Request is returned in this
+// situation.
+func handleImproperSelector(writer http.ResponseWriter, err error) {
+	log.Error().Err(err).Msg(unableToReadRuleSelector)
+	// return HTTP code 400 Bad Request
+	http.Error(writer, err.Error(), http.StatusBadRequest)
+}
+
+// handleMissingRule function handles situation when rule acknowledge can not
+// be found in internal data structure.  HTTP code 404 Not Found is returned in
+// this situation.
+func handleMissingRule(writer http.ResponseWriter, ruleSelector string) {
+	err := errors.New("rule not found -> justification can not be changed")
+	log.Error().Err(err).Msg("")
+	// return 404
+	http.Error(writer, err.Error(), http.StatusNotFound)
+}
+
+// addNewRule function add a new rule to existing map of acknowledges.
+func addNewRule(ruleSelector types.RuleSelector, justification string, createdBy string) {
+	// add new rule
+	acks[ruleSelector] = types.Acknowledge{
+		Acknowledged:  true,
+		Rule:          string(ruleSelector),
+		Justification: justification,
+		CreatedBy:     createdBy,
+		CreatedAt:     formattedNow(),
+		UpdatedAt:     formattedNow(),
+	}
+}
+
+// updateRuleJustification function updates justification of given rule. It
+// also changes UpdatedAt attribute.
+func updateRuleJustification(ruleSelector types.RuleSelector, justification types.AcknowledgementJustification) {
+	// (it is impossible to change the struct in a map directly!)
+	ack := acks[ruleSelector]
+
+	// TODO: ask if that attribute needs to be updated as well
+	// ack.CreatedBy = defaultUserName
+	ack.UpdatedAt = formattedNow()
+	ack.Justification = justification.Value
+
+	// update map
+	acks[ruleSelector] = ack
+}
+
+// updateRuleUpdatedAt function just UpdatedAt attribute.
+func updateRuleUpdatedAt(ruleSelector types.RuleSelector) {
+	// (it is impossible to change the struct in a map directly!)
+	ack := acks[ruleSelector]
+
+	// TODO: ask if that attribute needs to be updated as well
+	// ack.CreatedBy = defaultUserName
+	ack.UpdatedAt = formattedNow()
+
+	// update map
+	acks[ruleSelector] = ack
+}
+
+// returnRuleAckToClient returns information about selected rule ack to client.
+// This function also tries to process all errors.
+func returnRuleAckToClient(writer http.ResponseWriter, ack types.Acknowledge) {
+	// serialize the above data structure into JSON format
+	bytes, err := json.MarshalIndent(ack, "", "\t")
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+		return
+	}
+
+	// and send the serialized structure to client
+	_, err = writer.Write(bytes)
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Red Hat, Inc.
+Copyright © 2020, 2021 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -64,6 +64,36 @@ const (
 	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/enable"
 	// RuleClusterDetailEndpoint should return a list of all the clusters IDs affected by this rule
 	RuleClusterDetailEndpoint = "rule/{rule_selector}/clusters_detail/"
+
+	// Endpoints to acknowledge rule and to manipulate with
+	// acknowledgements.
+
+	// AckListEndpoint list acks from this account where the rule is
+	// active. Will return an empty list if this account has no acks.
+	AckListEndpoint = "ack"
+
+	// AckAcknowledgePostEndpoint acknowledges (and therefore hides) a rule
+	// from view in an account. If there's already an acknowledgement of
+	// this rule by this account, then return that. Otherwise, a new ack is
+	// created.
+	AckAcknowledgePostEndpoint = "ack"
+
+	// AckGetEndpoint acknowledges (and therefore hides) a rule from view
+	// in an account. This view handles listing, retrieving, creating and
+	// deleting acks. Acks are created and deleted by Insights rule ID, not
+	// by their own ack ID.
+	AckGetEndpoint = "ack/{rule_selector}"
+
+	// AckUpdateEndpoint updates an acknowledgement for a rule, by rule ID.
+	// A new justification can be supplied. The username is taken from the
+	// authenticated request. The updated ack is returned.
+	AckUpdateEndpoint = "ack/{rule_selector}"
+
+	// AckDeleteEndpoint deletes an acknowledgement for a rule, by its rule
+	// ID. If the ack existed, it is deleted and a 204 is returned.
+	// Otherwise, a 404 is returned.
+	AckDeleteEndpoint = "ack/{rule_selector}"
+
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
 )

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -56,6 +56,8 @@ func readRuleSelector(writer http.ResponseWriter, request *http.Request) (types.
 		return "", err
 	}
 
+	// check if the rule selector seems to be correct
+	_, _, err = parseRuleSelector(types.RuleSelector(ruleSelector))
 	if err != nil {
 		return "", err
 	}
@@ -377,6 +379,8 @@ type HittingClusters struct {
 func (server *HTTPServer) ruleClusterDetailEndpoint(writer http.ResponseWriter, request *http.Request) {
 	// read the selector
 	ruleSelector, err := readRuleSelector(writer, request)
+
+	// check for missing/improper selector
 	if err != nil {
 		log.Error().Err(err).Msg("unable to read rule selector")
 		// everything has been handled already

--- a/server/server.go
+++ b/server/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Red Hat, Inc.
+Copyright © 2020, 2021 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -107,6 +107,15 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(apiPrefix+ClustersEndpoint, server.readReportForClusters).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 	router.HandleFunc(apiPrefix+ClustersInOrgEndpoint, server.readReportForAllClustersInOrg).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+RuleClusterDetailEndpoint, server.ruleClusterDetailEndpoint).Methods(http.MethodGet)
+
+	// Acknowledgement-related endpoints. Please look into acks_handlers.go
+	// and acks_utils.go for more information about these endpoints
+	// prepared to be compatible with RHEL Insights Advisor.
+	router.HandleFunc(apiPrefix+AckListEndpoint, server.readAckList).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+AckAcknowledgePostEndpoint, server.acknowledgePost).Methods(http.MethodPost)
+	router.HandleFunc(apiPrefix+AckGetEndpoint, server.getAcknowledge).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+AckUpdateEndpoint, server.updateAcknowledge).Methods(http.MethodPut)
+	router.HandleFunc(apiPrefix+AckDeleteEndpoint, server.deleteAcknowledge).Methods(http.MethodDelete)
 
 	// OpenAPI specs
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)

--- a/types/types.go
+++ b/types/types.go
@@ -168,6 +168,42 @@ type KafkaOffset int64
 // DBDriver type for db driver enum
 type DBDriver int
 
+// Acknowledge represents user acknowledgement of given rule
+type Acknowledge struct {
+	Acknowledged  bool   `json:"-"` // let's skip this one in responses
+	Rule          string `json:"rule"`
+	Justification string `json:"justification"`
+	CreatedBy     string `json:"created_by"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+}
+
+// AcknowledgementsMetadata contains metadata about list of acknowledgements
+type AcknowledgementsMetadata struct {
+	Count int `json:"count"`
+}
+
+// AcknowledgementsResponse is structure returned to client in JSON
+// serialization format
+type AcknowledgementsResponse struct {
+	Metadata AcknowledgementsMetadata `json:"meta"`
+	Data     []Acknowledge            `json:"data"`
+}
+
+// AcknowledgementJustification data structure represents body of request with
+// specified justification of given acknowledgement
+type AcknowledgementJustification struct {
+	Value string `json:"justification"`
+}
+
+// AcknowledgementRuleSelectorJustification data structure represents body of
+// request with specified rule selector and justification of given
+// acknowledgement
+type AcknowledgementRuleSelectorJustification struct {
+	RuleSelector RuleSelector `json:"rule_id"`
+	Value        string       `json:"justification"`
+}
+
 const (
 	// DBDriverSQLite3 shows that db driver is sqlite
 	DBDriverSQLite3 DBDriver = iota


### PR DESCRIPTION
# Description

Ack endpoint

Fixes https://issues.redhat.com/browse/CCXDEV-5751

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## New REST API endpoints

### List of acked rules

List acks from this account where the rule is active. Will return an empty list if this account has no acks.

Request to the service:

```
curl localhost:8080/api/v1/ack
```

Response from the service:

```
{
        "meta": {
                "count": 5
        },
        "data": [
                {
                        "rule": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report|NODE_KUBELET_VERSION",
                        "justification": "Justification3",
                        "created_by": "tester3",
                        "created_at": "2021-09-04T17:11:35.130Z",
                        "updated_at": "2021-09-04T17:11:35.130Z"
                },
                {
                        "rule": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
                        "justification": "Justification4",
                        "created_by": "tester4",
                        "created_at": "2021-09-04T17:11:35.130Z",
                        "updated_at": "2021-09-04T17:11:35.130Z"
                },
                {
                        "rule": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR",
                        "justification": "Justification5",
                        "created_by": "tester5",
                        "created_at": "2021-09-04T17:11:35.130Z",
                        "updated_at": "2021-09-04T17:11:35.130Z"
                },
                {
                        "rule": "ccx_rules_ocp.external.rules.nodes_requirements_check.report|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
                        "justification": "Justification1",
                        "created_by": "tester1",
                        "created_at": "2021-09-04T17:11:35.130Z",
                        "updated_at": "2021-09-04T17:11:35.130Z"
                },
                {
                        "rule": "ccx_rules_ocp.external.bug_rules.bug_1766907.report|BUGZILLA_BUG_1766907",
                        "justification": "Justification2",
                        "created_by": "tester2",
                        "created_at": "2021-09-04T17:11:35.130Z",
                        "updated_at": "2021-09-04T17:11:35.130Z"
                }
        ]
}
```

### Ack rule with specified justification

Acknowledges (and therefore hides) a rule from view in an account. If there's
already an acknowledgement of this rule by this account, then return that.
Otherwise, a new ack is created.

#### Ack new rule

Request to the service:

```
curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"foo|bar", "justification":"xyzzy"}' "localhost:8080/api/v1/ack"
```

Response from the service:

```
< HTTP/1.1 201 Created
< Content-Type: application/json; charset=utf-8
< Date: Sun, 05 Sep 2021 14:29:33 GMT
< Content-Length: 168
< 
{
        "rule": "foo|bar",
        "justification": "xyzzy",
        "created_by": "onlineTester",
        "created_at": "2021-09-05T16:29:33+02:00",
        "updated_at": "2021-09-05T16:29:33+02:00"
}
```

#### Ack existing rule

Request to the service:

```
curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"existing|rule", "justification":"xyzzy"}' "localhost:8080/api/v1/ack"
```

Response from the service:

```
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Sun, 05 Sep 2021 14:35:51 GMT
< Content-Length: 168
< 
{
        "rule": "foo|bar",
        "justification": "xyzzy",
        "created_by": "onlineTester",
        "created_at": "2021-09-05T16:35:25+02:00",
        "updated_at": "2021-09-05T16:35:25+02:00"
}

```



### Ack rule

Acks acknowledge (and therefore hide) a rule from view in an account. This view
handles listing, retrieving, creating and deleting acks. Acks are created and
deleted by Insights rule ID, not by their own ack ID.

#### Ack new rule

Request to the service:

```
curl -v "localhost:8080/api/v1/ack/new|rule"
```

Response from the service:

```
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Sat, 04 Sep 2021 18:46:20 GMT
< Content-Length: 165
< 
{
        "rule": "new|rule",
        "justification": "?",
        "created_by": "onlineTester",
        "created_at": "2021-09-04T20:46:20+02:00",
        "updated_at": "2021-09-04T20:46:20+02:00"
}
```

#### Ack existing rule

Request to the service:

```
curl -v "localhost:8080/api/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
```

Response from the service:

```
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Sat, 04 Sep 2021 18:32:58 GMT
< Content-Length: 260
< 
{
        "rule": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR",
        "justification": "Justification5",
        "created_by": "onlineTester",
        "created_at": "2021-09-04T17:11:35.130Z",
        "updated_at": "2021-09-04T20:32:58+02:00"

```

Please note that just `updated_at` attribute is changed in this situation.

### Update rule

#### Update existing rule

Request to the service:

```
curl -v-X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/v1/ack/existing|rule"
```

Response from the service:

```
< HTTP/1.1 200 OK
< Date: Sun, 05 Sep 2021 05:47:46 GMT
< Content-Length: 169
< Content-Type: text/plain; charset=utf-8
< 
{
        "rule": "existing|rule",
        "justification": "xyzzy",
        "created_by": "onlineTester",
        "created_at": "2021-09-05T07:45:00+02:00",
        "updated_at": "2021-09-05T07:47:46+02:00"
}
```

#### Update non existing rule

Update an acknowledgement for a rule, by rule ID. A new justification can be
supplied. The username is taken from the authenticated request. The updated ack
is returned.

Request to the service:

```
curl -v -X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/v1/ack/new|rule"
```

Response from the service:

```
< HTTP/1.1 404 Not Found
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Sun, 05 Sep 2021 06:13:27 GMT
< Content-Length: 51
< 
rule not found -> justification can not be changed
```

### Delete rule

Delete an acknowledgement for a rule, by its rule ID. If the ack existed, it is
deleted and a 204 is returned. Otherwise, a 404 is returned.

#### Delete existing rule

Request to the service:

```
curl-v -X DELETE "localhost:8080/api/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
```

Response from the service:

```
< HTTP/1.1 204 No Content
< Date: Sat, 04 Sep 2021 17:44:32 GMT
< 
```

#### Delete nonexisting rule

Request to the service:

```
curl-v -X DELETE "localhost:8080/api/v1/ack/foobar|foobar"
```

Response from the service:

```
< HTTP/1.1 404 Not Found
< Date: Sat, 04 Sep 2021 17:44:35 GMT
< Content-Length: 0
< 
```

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
