### PR TITLE
Change paths' beginning from `/api/v1` to `/api/insights-results-aggregator/v1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Note: it is possible to use single dash or double dashes for all commands.
 ### Settings for localhost
 
 ```
-ADDRESS=localhost:8080/api/v1
+ADDRESS=localhost:8080/api/insights-results-aggregator/v1
 ```
 
 ### Basic endpoints
@@ -390,7 +390,7 @@ behaviour on client side.
 Example:
 
 ```
-ADDRESS=localhost:8080/api/v1
+ADDRESS=localhost:8080/api/insights-results-aggregator/v1
 
 clusters="ffffffff-ffff-ffff-ffff-000000000200
 ffffffff-ffff-ffff-ffff-000000000201
@@ -407,7 +407,7 @@ done
 ## List of clusters hitting specified rule
 
 ```
-curl 'localhost:8080/api/v1/rule/ccx_rules_ocp.external.rules.nodes_requirements_check.report|NODES_MINIMUM_REQUIREMENTS_NOT_MET/clusters_detail/'
+curl 'localhost:8080/api/insights-results-aggregator/v1/rule/ccx_rules_ocp.external.rules.nodes_requirements_check.report|NODES_MINIMUM_REQUIREMENTS_NOT_MET/clusters_detail/'
 ```
 
 ### An example of response:
@@ -460,7 +460,7 @@ List acks from this account where the rule is active. Will return an empty list 
 Request to the service:
 
 ```
-curl localhost:8080/api/v1/ack
+curl localhost:8080/api/insights-results-aggregator/v1/ack
 ```
 
 Response from the service:
@@ -521,7 +521,7 @@ Otherwise, a new ack is created.
 Request to the service:
 
 ```
-curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"foo|bar", "justification":"xyzzy"}' "localhost:8080/api/v1/ack"
+curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"foo|bar", "justification":"xyzzy"}' "localhost:8080/api/insights-results-aggregator/v1/ack"
 ```
 
 Response from the service:
@@ -546,7 +546,7 @@ Response from the service:
 Request to the service:
 
 ```
-curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"existing|rule", "justification":"xyzzy"}' "localhost:8080/api/v1/ack"
+curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"existing|rule", "justification":"xyzzy"}' "localhost:8080/api/insights-results-aggregator/v1/ack"
 ```
 
 Response from the service:
@@ -580,7 +580,7 @@ deleted by Insights rule ID, not by their own ack ID.
 Request to the service:
 
 ```
-curl -v "localhost:8080/api/v1/ack/new|rule"
+curl -v "localhost:8080/api/insights-results-aggregator/v1/ack/new|rule"
 ```
 
 Response from the service:
@@ -605,7 +605,7 @@ Response from the service:
 Request to the service:
 
 ```
-curl -v "localhost:8080/api/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
+curl -v "localhost:8080/api/insights-results-aggregator/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
 ```
 
 Response from the service:
@@ -634,7 +634,7 @@ Please note that just `updated_at` attribute is changed in this situation.
 Request to the service:
 
 ```
-curl -v-X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/v1/ack/existing|rule"
+curl -v-X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/insights-results-aggregator/v1/ack/existing|rule"
 ```
 
 Response from the service:
@@ -663,7 +663,7 @@ is returned.
 Request to the service:
 
 ```
-curl -v -X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/v1/ack/new|rule"
+curl -v -X PUT -H "Content-Type: application/json" --data '{"justification":"xyzzy"}' "localhost:8080/api/insights-results-aggregator/v1/ack/new|rule"
 ```
 
 Response from the service:
@@ -688,7 +688,7 @@ deleted and a 204 is returned. Otherwise, a 404 is returned.
 Request to the service:
 
 ```
-curl-v -X DELETE "localhost:8080/api/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
+curl-v -X DELETE "localhost:8080/api/insights-results-aggregator/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
 ```
 
 Response from the service:
@@ -704,7 +704,7 @@ Response from the service:
 Request to the service:
 
 ```
-curl-v -X DELETE "localhost:8080/api/v1/ack/foobar|foobar"
+curl-v -X DELETE "localhost:8080/api/insights-results-aggregator/v1/ack/foobar|foobar"
 ```
 
 Response from the service:

--- a/checks/check_localhost.sh
+++ b/checks/check_localhost.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ADDRESS=localhost:8080/api/v1
+ADDRESS=localhost:8080/api/insights-results-aggregator/v1
 
 mkdir -p localhost
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 [server]
 address = ":8080"
-api_prefix = "/api/v1/"
+api_prefix = "/api/insights-results-aggregator/v1/"
 api_spec_file = "openapi.json"
 
 [content]

--- a/test.sh
+++ b/test.sh
@@ -34,7 +34,7 @@ function test_rest_api() {
         return 1
     fi
     sleep 1
-    curl http://localhost:8080/api/v1/ || {
+    curl http://localhost:8080/api/insights-results-aggregator/v1/ || {
         echo -e "${COLORS_RED}server is not running(for some reason)${COLORS_RESET}"
         exit 1
     }

--- a/tests/rest/common.go
+++ b/tests/rest/common.go
@@ -31,7 +31,7 @@ type ClustersResponse struct {
 
 // common constants used by REST API tests
 const (
-	apiURL              = "http://localhost:8080/api/v1/"
+	apiURL              = "http://localhost:8080/api/insights-results-aggregator/v1/"
 	contentTypeHeader   = "Content-Type"
 	contentLengthHeader = "Content-Length"
 

--- a/tests/rest/entrypoint.go
+++ b/tests/rest/entrypoint.go
@@ -23,7 +23,7 @@ import (
 	"github.com/verdverm/frisby"
 )
 
-// checkRestAPIEntryPoint check if the entry point (usually /api/v1/) responds correctly to HTTP GET command
+// checkRestAPIEntryPoint check if the entry point (usually /api/insights-results-aggregator/v1/) responds correctly to HTTP GET command
 func checkRestAPIEntryPoint() {
 	f := frisby.Create("Check the entry point to REST API using HTTP GET method").Get(apiURL)
 	f.Send()


### PR DESCRIPTION
# Description

Change paths' beginning from `/api/v1` to `/api/insights-results-aggregator/v1`

Fixes #242

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
