### PR TITLE
Use Go 1.17 on CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,19 +16,20 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v1.44.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-
+          args: --timeout=3m
+          
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
@@ -40,3 +41,4 @@ jobs:
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
+          #

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 
 language: go
 go:
-- 1.16
+- 1.17
 
 jobs:
   include:

--- a/mock.go
+++ b/mock.go
@@ -149,7 +149,7 @@ func printHelp() int {
 }
 
 func printAuthors() int {
-	fmt.Println(authorsList)
+	fmt.Print(authorsList)
 
 	return ExitStatusOK
 }

--- a/server/errors.go
+++ b/server/errors.go
@@ -21,11 +21,6 @@ import (
 // responseDataError is used as the error message when the responses functions return an error
 const responseDataError = "Unexpected error during response data encoding"
 
-// AuthenticationError happens during auth problems, for example malformed token
-type AuthenticationError struct {
-	errString string
-}
-
 // handleServerError handles separate server errors and sends appropriate responses
 func handleServerError(err error) {
 	log.Error().Err(err).Msg("handleServerError()")

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -149,6 +149,7 @@ func (server *HTTPServer) serveContentWithGroups(writer http.ResponseWriter, req
 	}
 }
 
+/*
 // serveContent method implements the /content endpoint
 func (server *HTTPServer) serveContent(writer http.ResponseWriter, request *http.Request) {
 	err := responses.SendOK(writer, responses.BuildOkResponseWithData("content", server.Content))
@@ -158,6 +159,7 @@ func (server *HTTPServer) serveContent(writer http.ResponseWriter, request *http
 	}
 
 }
+*/
 
 func (server *HTTPServer) initGroupList() {
 	// let's mimick Content Service behaviour preciselly

--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,7 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)
 }
 
+/*
 // addCORSHeaders - middleware for adding headers that should be in any response
 func (server *HTTPServer) addCORSHeaders(nextHandler http.Handler) http.Handler {
 	return http.HandlerFunc(
@@ -145,7 +146,9 @@ func (server *HTTPServer) addCORSHeaders(nextHandler http.Handler) http.Handler 
 			nextHandler.ServeHTTP(w, r)
 		})
 }
+*/
 
+/*
 // handleOptionsMethod - middleware for handling OPTIONS method
 func (server *HTTPServer) handleOptionsMethod(nextHandler http.Handler) http.Handler {
 	return http.HandlerFunc(
@@ -157,3 +160,4 @@ func (server *HTTPServer) handleOptionsMethod(nextHandler http.Handler) http.Han
 			}
 		})
 }
+*/

--- a/storage/rule_feedback.go
+++ b/storage/rule_feedback.go
@@ -51,6 +51,7 @@ func (storage MemoryStorage) AddOrUpdateFeedbackOnRule(
 	return nil
 }
 
+/*
 // addOrUpdateUserFeedbackOnRuleForCluster adds or updates feedback
 // will update user vote and messagePtr if the pointers are not nil
 func (storage MemoryStorage) addOrUpdateUserFeedbackOnRuleForCluster(
@@ -62,6 +63,7 @@ func (storage MemoryStorage) addOrUpdateUserFeedbackOnRuleForCluster(
 ) error {
 	return nil
 }
+*/
 
 // GetUserFeedbackOnRule gets user feedback from DB
 func (storage MemoryStorage) GetUserFeedbackOnRule(

--- a/tests/rest/common.go
+++ b/tests/rest/common.go
@@ -28,9 +28,8 @@ type ClustersResponse struct {
 
 // common constants used by REST API tests
 const (
-	apiURL              = "http://localhost:8080/api/insights-results-aggregator/v1/"
-	contentTypeHeader   = "Content-Type"
-	contentLengthHeader = "Content-Length"
+	apiURL            = "http://localhost:8080/api/insights-results-aggregator/v1/"
+	contentTypeHeader = "Content-Type"
 
 	// ContentTypeJSON represents MIME type for JSON format
 	ContentTypeJSON = "application/json; charset=utf-8"


### PR DESCRIPTION
# Description

Use Go 1.17 on CI

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
