### PR TITLE
Adding upgrade-risks-prediction endpoint with fixed results on storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Mock service mimicking Insights Results Aggregator
     * [Delete rule](#delete-rule)
         * [Delete existing rule](#delete-existing-rule)
         * [Delete nonexisting rule](#delete-nonexisting-rule)
-* [Upgrade risks prediction results](#upgrade-risks-prediction-endpoint)
+* [Upgrade risks prediction results](#upgrade-risks-prediction-results)
 * [BDD tests](#bdd-tests)
 * [Package manifest](#package-manifest)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Mock service mimicking Insights Results Aggregator
     * [Delete rule](#delete-rule)
         * [Delete existing rule](#delete-existing-rule)
         * [Delete nonexisting rule](#delete-nonexisting-rule)
+* [Upgrade risks prediction results](#upgrade-risks-prediction-endpoint)
 * [BDD tests](#bdd-tests)
 * [Package manifest](#package-manifest)
 
@@ -726,7 +727,7 @@ deleted and a 204 is returned. Otherwise, a 404 is returned.
 Request to the service:
 
 ```
-curl-v -X DELETE "localhost:8080/api/insights-results-aggregator/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
+curl -v -X DELETE "localhost:8080/api/insights-results-aggregator/v1/ack/ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report|AUTH_OPERATOR_PROXY_ERROR"
 ```
 
 Response from the service:
@@ -742,7 +743,7 @@ Response from the service:
 Request to the service:
 
 ```
-curl-v -X DELETE "localhost:8080/api/insights-results-aggregator/v1/ack/foobar|foobar"
+curl -v -X DELETE "localhost:8080/api/insights-results-aggregator/v1/ack/foobar|foobar"
 ```
 
 Response from the service:
@@ -754,7 +755,40 @@ Response from the service:
 < 
 ```
 
+## Upgrade risks prediction results
 
+To use the Upgrade Risks Prediction endpoint:
+
+```
+curl "localhost:8080/api/insights-results-aggregator/v1/upgrade-risks-prediction/cluster/{cluster_id}
+```
+
+Response from the service:
+
+```
+< HTTP/1.1 200 OK
+< Content-Type: application/json; charset=utf-8
+< Date: Wed, 15 Feb 2023 08:44:11 GMT
+< Content-Length: 136
+< 
+{"status":"ok","upgrade_recommendation":{"upgrade_recommended":true,"upgrade_risks_predictors":{"alerts":[],"operator_conditions":[]}}}
+```
+
+### Clusters that return valid data
+
+For the clusters not listed in the sections bellow, a 404 will be returned.
+
+#### Cluster returning a positive upgrade risks prediction (upgrade recommended)
+
+```
+00000001-624a-49a5-bab8-4fdc5e51a266
+```
+
+#### Cluster returning a negative upgrade risks prediction (upgrade recommended)
+
+```
+00000003-eeee-eeee-eeee-000000000001
+```
 
 ## BDD tests
 

--- a/openapi.json
+++ b/openapi.json
@@ -927,6 +927,71 @@
           "prod"
         ]
       }
+    },
+    "upgrade-risks-prediction/cluster/{clusterId}": {
+      "get": {
+        "summary": "",
+        "operationId": "getUpgradeRisksPrediction",
+        "description": "The title of the rule, a short description.",
+        "parameters": [
+          {
+            "name": "clusterId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 36,
+              "maxLength": 36,
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "upgrade_recommendation": {
+                      "type": "object",
+                      "properties": {
+                        "upgrade_recommended": {
+                          "type": "boolean"
+                        },
+                        "upgrade_risks_predictors": {
+                          "type": "object",
+                          "properties": {
+                            "alerts": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minimum": 0
+                              }
+                            },
+                            "operator_conditions": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minimum": 0
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "security": [],

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -100,6 +100,9 @@ const (
 	// Otherwise, a 404 is returned.
 	AckDeleteEndpoint = "ack/{rule_selector}"
 
+	// UpgradeRisksPredictionEndpoint
+	UpgradeRisksPredictionEndpoint = "upgrade-risks-prediction/cluster/{cluster}"
+
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
 )

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -100,7 +100,8 @@ const (
 	// Otherwise, a 404 is returned.
 	AckDeleteEndpoint = "ack/{rule_selector}"
 
-	// UpgradeRisksPredictionEndpoint
+	// UpgradeRisksPredictionEndpoint returns the prediction about upgrading
+	// the given cluster.
 	UpgradeRisksPredictionEndpoint = "upgrade-risks-prediction/cluster/{cluster}"
 
 	// MetricsEndpoint returns prometheus metrics

--- a/server/server.go
+++ b/server/server.go
@@ -130,6 +130,10 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(apiPrefix+AckUpdateEndpoint, server.updateAcknowledge).Methods(http.MethodPut)
 	router.HandleFunc(apiPrefix+AckDeleteEndpoint, server.deleteAcknowledge).Methods(http.MethodDelete)
 
+	// Upgrade risks prediction endpoints. Please look into upgrade_risks_prediction.go
+	// for more information about this endpoint
+	router.HandleFunc(apiPrefix+UpgradeRisksPredictionEndpoint, server.upgradeRisksPrediction).Methods(http.MethodGet)
+
 	// OpenAPI specs
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)
 }

--- a/server/upgrade_risks_prediction.go
+++ b/server/upgrade_risks_prediction.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/RedHatInsights/insights-operator-utils/responses"
+	"github.com/rs/zerolog/log"
+)
+
+// method upgradeRisksPrediction return a recommendation to upgrade or not a cluster
+// and a list of the alerts/operator conditions that were taken into account if the
+// upgrade is not recommended.
+//
+// Response format should look like:
+//
+//	{
+//		"upgrade_recommended": false,
+//		"upgrade_risks_predictors": {
+//			"alerts": ["alert1", "alert2"],
+//			"operator_conditions": ["foc1", "foc2"]
+//		}
+//	}
+func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, request *http.Request) {
+	clusterName, err := readClusterName(writer, request)
+	if err != nil {
+		// everything has been handled already
+		return
+	}
+
+	prediction, err := server.Storage.GetPredictionForCluster(clusterName)
+	if err != nil {
+		log.Error().Err(err).Msg("error retrieving upgrade prediction from storage")
+		handleServerError(err)
+		return
+	}
+
+	writer.Header().Set(contentType, appJSON)
+	err = responses.SendOK(writer, responses.BuildOkResponseWithData("upgrade_recommendation", prediction))
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}

--- a/server/upgrade_risks_prediction.go
+++ b/server/upgrade_risks_prediction.go
@@ -47,6 +47,10 @@ func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, req
 	if err != nil {
 		log.Error().Err(err).Msg("error retrieving upgrade prediction from storage")
 		handleServerError(err)
+		err = responses.SendNotFound(writer, err.Error())
+		if err != nil {
+			log.Error().Err(err).Msg(responseDataError)
+		}
 		return
 	}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,6 +22,7 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -90,6 +91,7 @@ type Storage interface {
 		userID types.UserID,
 	) (map[types.RuleID]types.UserVote, error)
 	GetRuleWithContent(ruleID types.RuleID, ruleErrorKey types.ErrorKey) (*types.RuleWithContent, error)
+	GetPredictionForCluster(cluster types.ClusterName) (*types.UpgradeRiskPrediction, error)
 }
 
 // MemoryStorage data structure represents configuration of memory storage used
@@ -393,4 +395,29 @@ func (storage MemoryStorage) GetRuleByID(ruleID types.RuleID) (*types.Rule, erro
 	var rule types.Rule
 
 	return &rule, nil
+}
+
+// GetPredictionForCluster gets a prediction for the cluster
+func (storage MemoryStorage) GetPredictionForCluster(cluster types.ClusterName) (*types.UpgradeRiskPrediction, error) {
+	switch cluster {
+	case "00000001-624a-49a5-bab8-4fdc5e51a266":
+		return &types.UpgradeRiskPrediction{
+			Recommended: true,
+			Predictors: types.UpgradeRiskPredictors{
+				Alerts:             []string{},
+				OperatorConditions: []string{},
+			},
+		}, nil
+	case "00000003-eeee-eeee-eeee-000000000001":
+		return &types.UpgradeRiskPrediction{
+			Recommended: false,
+			Predictors: types.UpgradeRiskPredictors{
+				Alerts:             []string{"alert1"},
+				OperatorConditions: []string{"foc1", "foc2"},
+			},
+		}, nil
+	}
+
+	return nil, fmt.Errorf("cluster not found")
+
 }

--- a/types/types.go
+++ b/types/types.go
@@ -204,6 +204,20 @@ type AcknowledgementRuleSelectorJustification struct {
 	Value        string       `json:"justification"`
 }
 
+// UpgradeRiskPredictors data structure represents the alerts and conditions
+// that are contained in an upgrade-risk-predictions response
+type UpgradeRiskPredictors struct {
+	Alerts             []string `json:"alerts"`
+	OperatorConditions []string `json:"operator_conditions"`
+}
+
+// UpgradeRiskPrediction data structure represents body of the response
+// for an upgrade-risk-predictions request
+type UpgradeRiskPrediction struct {
+	Recommended bool                  `json:"upgrade_recommended"`
+	Predictors  UpgradeRiskPredictors `json:"upgrade_risks_predictors"`
+}
+
 const (
 	// DBDriverSQLite3 shows that db driver is sqlite
 	DBDriverSQLite3 DBDriver = iota


### PR DESCRIPTION
# Description

Added upgrade-risk-prediction endpoint to the mock service.

I added a small storage function to retrieve different results depending on the cluster_id

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Locally tested

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
