### PR TITLE
Normalize the upgrade-risks-prediction endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ Response from the service:
 To use the Upgrade Risks Prediction endpoint:
 
 ```
-curl "localhost:8080/api/insights-results-aggregator/v1/upgrade-risks-prediction/cluster/{cluster_id}
+curl "localhost:8080/api/insights-results-aggregator/v1/cluster/{cluster_id}/upgrade-risks-prediction
 ```
 
 Response from the service:

--- a/openapi.json
+++ b/openapi.json
@@ -928,7 +928,7 @@
         ]
       }
     },
-    "upgrade-risks-prediction/cluster/{clusterId}": {
+    "/cluster/{clusterId}/upgrade-risks-prediction": {
       "get": {
         "summary": "",
         "operationId": "getUpgradeRisksPrediction",

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -102,7 +102,7 @@ const (
 
 	// UpgradeRisksPredictionEndpoint returns the prediction about upgrading
 	// the given cluster.
-	UpgradeRisksPredictionEndpoint = "upgrade-risks-prediction/cluster/{cluster}"
+	UpgradeRisksPredictionEndpoint = "cluster/{cluster}/upgrade-risks-prediction"
 
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"


### PR DESCRIPTION
# Description

The endpoint created a couple of commits ago looks very different from the already existing ones. This PR will fix that to make them to look similar

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
