### PR TITLE
[CCXDEV-10678] Add alerts and focs url openapi changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,11 @@ c60ba611-6af4-4d62-9b9e-36344da5e7bc
 897ec1a1-4679-4122-aacb-f0ae9f9e1a5f
 ```
 
+#### Cluster returning 404 due to no data in RHOBS for this cluster
+
+```
+234ec1a1-4679-4122-aacb-f0ae9f9e1a56
+```
 ## BDD tests
 
 Behaviour tests for this service are included in [Insights Behavioral

--- a/openapi.json
+++ b/openapi.json
@@ -981,6 +981,9 @@
                                   },
                                   "severity": {
                                     "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
                                   }
                                 }                                
                               }
@@ -998,6 +1001,9 @@
                                     "type": "string"
                                   },
                                   "reason": {
+                                    "type": "string"
+                                  },
+                                  "url": {
                                     "type": "string"
                                   }
                                 }
@@ -1026,7 +1032,7 @@
             "description": "Status NoContent: happens when the cluster is managed. The upgrade risks prediction is not available for this kind of clusters."
           },
           "404": {
-            "description": "Status NotFound: happens when the cluster cannot be found in the Observatorium data"
+            "description": "Status NotFound: happens when the cluster has no data in Observatorium"
           },
           "503": {
             "description": "Status NotAvailable: happens when the AMS API or the Upgrade Risks Prediction service is not available."

--- a/server/upgrade_risks_prediction.go
+++ b/server/upgrade_risks_prediction.go
@@ -68,6 +68,7 @@ const (
 //			]
 //		}
 //	}
+
 func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, request *http.Request) {
 	clusterName, err := readClusterName(writer, request)
 	if err != nil {
@@ -117,55 +118,7 @@ func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, req
 		}
 
 		if clusterName == ClusterOkFailUpgrade {
-			prediction.Recommended = false
-			prediction.Predictors.Alerts = append(
-				prediction.Predictors.Alerts,
-				types.Alert{
-					Name:      "alert1",
-					Namespace: "namespace1",
-					Severity:  "info",
-					URL:       "https://my-cluster.com/monitoring/alerts?orderBy=asc&sortBy=Severity&alert-name=alert1",
-				},
-				types.Alert{
-					Name:      "alert2",
-					Namespace: "namespace2",
-					Severity:  "warning",
-					URL:       "https://my-cluster.com/monitoring/alerts?orderBy=asc&sortBy=Severity&alert-name=alert2",
-				},
-				types.Alert{
-					Name:      "alert3",
-					Namespace: "namespace3",
-					Severity:  "critical",
-					URL:       "https://my-cluster.com/monitoring/alerts?orderBy=asc&sortBy=Severity&alert-name=alert3",
-				},
-			)
-			prediction.Predictors.OperatorConditions = append(
-				prediction.Predictors.OperatorConditions,
-				types.OperatorCondition{
-					Name:      "foc1",
-					Condition: "Degraded",
-					Reason:    "NotExpected",
-					URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc1",
-				},
-				types.OperatorCondition{
-					Name:      "foc2",
-					Condition: "Failing",
-					Reason:    "NotExpected",
-					URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc2",
-				},
-				types.OperatorCondition{
-					Name:      "foc3",
-					Condition: "Not Available",
-					Reason:    "NotExpected",
-					URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc3",
-				},
-				types.OperatorCondition{
-					Name:      "foc4",
-					Condition: "Not Upgradeable",
-					Reason:    "NotExpected",
-					URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc4",
-				},
-			)
+			buildOkResponse(prediction)
 		}
 
 		writer.Header().Set(contentType, appJSON)
@@ -178,4 +131,56 @@ func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, req
 			log.Error().Err(err).Msg(responseDataError)
 		}
 	}
+}
+
+func buildOkResponse(prediction *types.UpgradeRiskPrediction) {
+	prediction.Recommended = false
+	prediction.Predictors.Alerts = append(
+		prediction.Predictors.Alerts,
+		types.Alert{
+			Name:      "alert1",
+			Namespace: "namespace1",
+			Severity:  "info",
+			URL:       "https://my-cluster.com/monitoring/alerts?orderBy=asc&sortBy=Severity&alert-name=alert1",
+		},
+		types.Alert{
+			Name:      "alert2",
+			Namespace: "namespace2",
+			Severity:  "warning",
+			URL:       "https://my-cluster.com/monitoring/alerts?orderBy=asc&sortBy=Severity&alert-name=alert2",
+		},
+		types.Alert{
+			Name:      "alert3",
+			Namespace: "namespace3",
+			Severity:  "critical",
+			URL:       "https://my-cluster.com/monitoring/alerts?orderBy=asc&sortBy=Severity&alert-name=alert3",
+		},
+	)
+	prediction.Predictors.OperatorConditions = append(
+		prediction.Predictors.OperatorConditions,
+		types.OperatorCondition{
+			Name:      "foc1",
+			Condition: "Degraded",
+			Reason:    "NotExpected",
+			URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc1",
+		},
+		types.OperatorCondition{
+			Name:      "foc2",
+			Condition: "Failing",
+			Reason:    "NotExpected",
+			URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc2",
+		},
+		types.OperatorCondition{
+			Name:      "foc3",
+			Condition: "Not Available",
+			Reason:    "NotExpected",
+			URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc3",
+		},
+		types.OperatorCondition{
+			Name:      "foc4",
+			Condition: "Not Upgradeable",
+			Reason:    "NotExpected",
+			URL:       "https://my-cluster.com/k8s/cluster/config.openshift.io~v1~ClusterOperator/foc4",
+		},
+	)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -209,6 +209,7 @@ type Alert struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 	Severity  string `json:"severity"`
+	URL       string `json:"url"`
 }
 
 // OperatorCondition data structure representing a single operator condition
@@ -216,6 +217,7 @@ type OperatorCondition struct {
 	Name      string `json:"name"`
 	Condition string `json:"condition"`
 	Reason    string `json:"reason"`
+	URL       string `json:"url"`
 }
 
 // UpgradeRisksPredictors data structure represents the alerts and conditions


### PR DESCRIPTION
# Description

Add alerts and focs urls redirected from the data-eng service.

Part of [CCXDEV-10678](https://issues.redhat.com/browse/CCXDEV-10678)

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Locally.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
