### PR TITLE
Valid report including timestamps

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -517,7 +517,7 @@ type RequestStatus struct {
 func constructRequestsList(requestIDs []types.RequestID) []RequestStatus {
 	states := make([]RequestStatus, len(requestIDs))
 
-	for i, _ := range requestIDs {
+	for i := range requestIDs {
 		states[i].RequestID = string(requestIDs[i])
 		states[i].Valid = true
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -506,6 +506,30 @@ func logRequestID(requestID types.RequestID) {
 	log.Info().Str("request_id", string(requestID)).Msg(requestParameter)
 }
 
+// RequestStatus contains description about one request ID
+type RequestStatus struct {
+	RequestID string `json:"requestID"`
+	Valid     bool   `json:"valid"`
+	Received  string `json:"received"`
+	Processed string `json:"processed"`
+}
+
+func constructRequestsList(requestIDs []types.RequestID) []RequestStatus {
+	states := make([]RequestStatus, len(requestIDs))
+
+	for i, _ := range requestIDs {
+		states[i].RequestID = string(requestIDs[i])
+		states[i].Valid = true
+
+		received := time.Date(2000, time.November, 1, 1, 0, 0, 999, time.UTC).Format(time.RFC3339Nano)
+		states[i].Received = received
+
+		processed := time.Now().UTC().Format(time.RFC3339Nano)
+		states[i].Processed = processed
+	}
+	return states
+}
+
 // readListOfRequestIDs method implements endpoint that should return a list of
 // all request IDs for given cluster
 func (server *HTTPServer) readListOfRequestIDs(writer http.ResponseWriter, request *http.Request) {
@@ -528,7 +552,7 @@ func (server *HTTPServer) readListOfRequestIDs(writer http.ResponseWriter, reque
 	// prepare data structure
 	responseData := map[string]interface{}{"status": "ok"}
 	responseData["cluster"] = string(clusterName)
-	responseData["requests"] = requestIDs
+	responseData["requests"] = constructRequestsList(requestIDs)
 
 	err = responses.SendOK(writer, responseData)
 	if err != nil {


### PR DESCRIPTION
# Description

Valid report including timestamps:

```
 curl localhost:8080/api/insights-results-aggregator/v2/cluster/34c3ecc5-624a-49a5-bab8-4fdc5e51a267/requests/ | jq .
```

Should output:

```json
{
  "cluster": "34c3ecc5-624a-49a5-bab8-4fdc5e51a267",
  "requests": [
    {
      "requestID": "1duzaoao0l1b230ipv0rb4sqe8",
      "valid": true,
      "received": "2000-11-01T01:00:00.000000999Z",
      "processed": "2023-05-26T13:33:02.216970365Z"
    },
    {
      "requestID": "1yjdje758zgyy3ksfr732yb1cl",
      "valid": true,
      "received": "2000-11-01T01:00:00.000000999Z",
      "processed": "2023-05-26T13:33:02.216972191Z"
    },
    {
      "requestID": "2ukce6u74rm9e12mplu6liqzsv",
      "valid": true,
      "received": "2000-11-01T01:00:00.000000999Z",
      "processed": "2023-05-26T13:33:02.216973581Z"
    },
...
...
...
    {
      "requestID": "2drtvjlisiqww1c93kugqyboyc",
      "valid": true,
      "received": "2000-11-01T01:00:00.000000999Z",
      "processed": "2023-05-26T13:33:02.216995705Z"
    }
  ],
  "status": "ok"
}
```

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

See above example

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
