### PR TITLE
POST variant of REST API endpoint to list all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Mock service mimicking Insights Results Aggregator
         * [Cluster returning 404 due to no data in RHOBS for this cluster](#cluster-returning-404-due-to-no-data-in-rhobs-for-this-cluster)
 * [Endpoints for On Demand Data Gathering](#endpoints-for-on-demand-data-gathering)
     * [List of all rule hits](#list-of-all-rule-hits)
+        * [GET variant](#get-variant)
+        * [POST variant](#post-variant)
         * [Response from the service](#response-from-the-service)
         * [Response for improper request (bad cluster name)](#response-for-improper-request-bad-cluster-name)
     * [Check status of given `request-id`](#check-status-of-given-request-id)
@@ -844,11 +846,31 @@ c60ba611-6af4-4d62-9b9e-36344da5e7bc
 
 List of all rule hits (all identified by x-rh-insights-request-id) for given cluster (the list also contain timestamps).
 
-Request to the service:
+Request to the service
+
+#### GET variant
 
 ```
 curl -v localhost:8080/api/insights-results-aggregator/v2/cluster/34c3ecc5-624a-49a5-bab8-4fdc5e51a267/requests/
 ```
+
+#### POST variant
+
+```
+curl -v -X POST -d @requests.json localhost:8080/api/insights-results-aggregator/v2/cluster/34c3ecc5-624a-49a5-bab8-4fdc5e51a267/requests/
+```
+
+Where `requests.json` looks like:
+
+```json
+[
+    "1duzaoao0l1b230ipv0rb4sqe8",
+    "1yjdje758zgyy3ksfr732yb1cl",
+    "eeeeeeeeeeeeeeeeeeeeeeeeee",
+    "2ukce6u74rm9e12mplu6liqzsv"
+]
+```
+
 
 #### Response from the service
 

--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=50
+threshold=52
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -602,6 +602,96 @@ func (server *HTTPServer) readListOfRequestIDs(writer http.ResponseWriter, reque
 	}
 }
 
+type RequestList []types.RequestID
+
+func dumpRequest(request *http.Request) {
+	dump, err := httputil.DumpRequest(request, true)
+	if err != nil {
+		log.Error().Err(err).Msg("dump error")
+		return
+	}
+	log.Info().Str("dump", string(dump)).Msg("dump of request")
+}
+
+func readRequestList(writer http.ResponseWriter, request *http.Request) (RequestList, error) {
+	var requestList RequestList
+	err := json.NewDecoder(request.Body).Decode(&requestList)
+	if err != nil {
+		log.Error().Err(err).Msg("getting list of requests")
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return nil, err
+	}
+	return requestList, nil
+}
+
+func logRequestIDs(message string, requestList RequestList) {
+	log.Info().Msg(message)
+	for _, requestID := range requestList {
+		log.Info().Str("ID", string(requestID)).Msg("   ")
+	}
+}
+
+func filterRequestIDs(requestIDs, requestList RequestList) RequestList {
+	// filter request IDs using the rather inneficient way!
+	var filteredIDs RequestList
+	for _, requestID := range requestIDs {
+		found := false
+		for _, wantedID := range requestList {
+			if requestID == wantedID {
+				found = true
+				break
+			}
+		}
+		if found {
+			filteredIDs = append(filteredIDs, requestID)
+		}
+	}
+	return filteredIDs
+}
+
+// readListOfRequestIDsPostVariant method implements endpoint that should return a list of
+// request IDs for given cluster
+func (server *HTTPServer) readListOfRequestIDsPostVariant(writer http.ResponseWriter, request *http.Request) {
+	dumpRequest(request)
+	requestList, err := readRequestList(writer, request)
+	if err != nil {
+		return
+	}
+	logRequestIDs("List of requests send to service", requestList)
+
+	clusterName, err := readClusterName(writer, request)
+	if err != nil {
+		err = responses.SendBadRequest(writer, err.Error())
+		if err != nil {
+			log.Error().Err(err).Msg(responseDataError)
+		}
+		return
+	}
+	logClusterName(clusterName)
+
+	requestIDs, found := data.RequestIDs[clusterName]
+	if !found {
+		err := responses.SendNotFound(writer, requestsForClusterNotFound)
+		if err != nil {
+			log.Error().Err(err).Msg(responseDataError)
+		}
+		return
+	}
+
+	filteredIDs := filterRequestIDs(requestIDs, requestList)
+	logRequestIDs("Filtered IDs", filteredIDs)
+
+	// prepare data structure
+	responseData := map[string]interface{}{"status": "ok"}
+	responseData["cluster"] = string(clusterName)
+	responseData["requests"] = constructRequestsList(filteredIDs)
+
+	err = responses.SendOK(writer, responseData)
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}
+
 // readStatusOfRequestID method implements endpoint that should return a status
 // for given request ID. Currently the status is set to "processed" or
 // "unknown" because we won't have information about "in-between" states.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -602,6 +602,7 @@ func (server *HTTPServer) readListOfRequestIDs(writer http.ResponseWriter, reque
 	}
 }
 
+// RequestList represents sequence of request IDs
 type RequestList []types.RequestID
 
 func dumpRequest(request *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -142,6 +142,7 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	// Endpoints to manipulate with simplified rule results stored
 	// independently under "tracker_id" identifier
 	router.HandleFunc(apiPrefix+ListAllRequestIDs, server.readListOfRequestIDs).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+ListAllRequestIDs, server.readListOfRequestIDsPostVariant).Methods(http.MethodPost)
 	router.HandleFunc(apiPrefix+StatusOfRequestID, server.readStatusOfRequestID).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+RuleHitsForRequestID, server.readRuleHitsForRequestID).Methods(http.MethodGet)
 


### PR DESCRIPTION
# Description

POST variant of REST API endpoint to list all requests

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

Can be run locally:

```
curl -v -X POST -d @requests.json localhost:8080/api/insights-results-aggregator/v2/cluster/34c3ecc5-624a-49a5-bab8-4fdc5e51a267/requests/
```

Where `requests.json` looks like:

```json
[
    "1duzaoao0l1b230ipv0rb4sqe8",
    "1yjdje758zgyy3ksfr732yb1cl",
    "eeeeeeeeeeeeeeeeeeeeeeeeee",
    "2ukce6u74rm9e12mplu6liqzsv"
]
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
