### PR TITLE
Support for running integration tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ help: ## Show this help screen
 	@echo 'Available targets are:'
 	@echo ''
 	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 	@echo ''
 
 function_list: ${BINARY} ## List all functions in generated binary file

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ integration_tests: ## Run all integration tests
 	@echo "Running all integration tests"
 	@./test.sh
 
+local_integration_tests: ## Run all integration tests locally
+	@echo "Running all integration tests"
+	@./rest-api-tests.sh
+
 license:
 	GO111MODULE=off go get -u github.com/google/addlicense && \
 		addlicense -c "Red Hat, Inc" -l "apache" -v ./

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ test                 Run the unit tests
 cover                Generate HTML pages with code coverage
 coverage             Display code coverage on terminal
 integration_tests    Run all integration tests
+local_integration_tests Run all integration tests locally
 help                 Show this help screen
 function_list        List all functions in generated binary file
 ```

--- a/README.md
+++ b/README.md
@@ -117,27 +117,27 @@ Usage: make <OPTIONS> ... <TARGETS>
 
 Available targets are:
 
-build                Build binary containing service executable
-build-cover          Build binary with code coverage detection support
-fmt                  Run go fmt -w for all sources
-lint                 Run golint
-vet                  Run go vet. Report likely mistakes in source code
-cyclo                Run gocyclo
-ineffassign          Run ineffassign checker
-shellcheck           Run shellcheck
-errcheck             Run errcheck
-goconst              Run goconst checker
-gosec                Run gosec checker
-abcgo                Run ABC metrics checker
-style                Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
-run                  Build the project and executes the binary
-test                 Run the unit tests
-cover                Generate HTML pages with code coverage
-coverage             Display code coverage on terminal
-integration_tests    Run all integration tests
+build                   Build binary containing service executable
+build-cover             Build binary with code coverage detection support
+fmt                     Run go fmt -w for all sources
+lint                    Run golint
+vet                     Run go vet. Report likely mistakes in source code
+cyclo                   Run gocyclo
+ineffassign             Run ineffassign checker
+shellcheck              Run shellcheck
+errcheck                Run errcheck
+goconst                 Run goconst checker
+gosec                   Run gosec checker
+abcgo                   Run ABC metrics checker
+style                   Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
+run                     Build the project and executes the binary
+test                    Run the unit tests
+cover                   Generate HTML pages with code coverage
+coverage                Display code coverage on terminal
+integration_tests       Run all integration tests
 local_integration_tests Run all integration tests locally
-help                 Show this help screen
-function_list        List all functions in generated binary file
+help                    Show this help screen
+function_list           List all functions in generated binary file
 ```
 
 ## Usage

--- a/rest-api-tests.sh
+++ b/rest-api-tests.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COLORS_RED='\033[0;31m'
+COLORS_RESET='\033[0m'
+VERBOSE_OUTPUT=false
+
+echo bash version is:
+bash --version
+
+if [[ $* == *verbose* ]] || [[ -n "${VERBOSE}" ]]; then
+    # print all possible logs
+    VERBOSE_OUTPUT=true
+fi
+
+function start_service() {
+    if [ "$NO_SERVICE" = true ]; then
+        echo "Not starting service"
+        return
+    fi
+
+    echo "Starting a service"
+    ./insights-results-aggregator-mock ||
+        echo -e "${COLORS_RED}service exited with error${COLORS_RESET}" &
+    # shellcheck disable=2181
+    if [ $? -ne 0 ]; then
+        echo "Could not start the service"
+        exit 1
+    fi
+}
+
+function test_rest_api() {
+    start_service
+    sleep 1
+
+    echo "Building REST API tests utility"
+    if go build -o rest-api-tests tests/rest_api_tests.go; then
+        echo "REST API tests build ok"
+    else
+        echo "Build failed"
+        return 1
+    fi
+    sleep 1
+
+    curl http://localhost:8080/api/insights-results-aggregator/v2/ || {
+        echo -e "${COLORS_RED}server is not running(for some reason)${COLORS_RESET}"
+        exit 1
+    }
+
+    OUTPUT=$(./rest-api-tests 2>&1)
+    EXIT_CODE=$?
+
+    if [ "$VERBOSE_OUTPUT" = true ]; then
+        echo "$OUTPUT"
+    else
+        echo "$OUTPUT" | grep -v -E "^Pass "
+    fi
+
+    return $EXIT_CODE
+}
+
+function cleanup() {
+    print_descendent_pids() {
+        pids=$(pgrep -P "$1")
+        echo "$pids"
+        for pid in $pids; do
+            print_descendent_pids "$pid"
+        done
+    }
+
+    echo Exiting and killing all children...
+
+    children=$(print_descendent_pids $$)
+
+    # disable the message when you send stop signal to child processes
+    set +m
+
+    for pid in $(echo -en "$children"); do
+        # nicely asking a process to commit suicide
+        if ! kill -PIPE "$pid" &>/dev/null; then
+            # we even gave them plenty of time to think
+            sleep 1
+        fi
+    done
+
+    # restore the message back since we want to know that process wasn't stopped correctory
+    # set -m
+
+    for pid in $(echo -en "$children"); do
+        # murdering those who're alive
+        kill -9 "$pid" &>/dev/null
+    done
+
+    sleep 1
+}
+trap cleanup EXIT
+
+echo -e "------------------------------------------------------------------------------------------------"
+
+make build
+test_rest_api
+exit $?


### PR DESCRIPTION
# Description

Support for running integration tests locally

Fixes https://issues.redhat.com/browse/CCXDEV-11503

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

```
$ make local_integration_tests
```

Expected output:

```
Running all integration tests
bash version is:
GNU bash, version 5.0.17(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
------------------------------------------------------------------------------------------------
make[1]: Entering directory '/home/ptisnovs/ccx/insights-results-aggregator-mock'
go build -ldflags="-X 'main.BuildTime=Thu 27 Jul 2023 09:04:55 AM CEST' -X 'main.BuildVersion=0.1' -X 'main.BuildBranch=support-for-running-integration-tests-locally' -X 'main.BuildCommit=8a54a12e667e00c2975b8885404dca5e0ac647dc'"
make[1]: Leaving directory '/home/ptisnovs/ccx/insights-results-aggregator-mock'
Starting a service
9:04AM INF Version: 0.1 type=init
9:04AM INF Build time: Thu 27 Jul 2023 09:04:55 AM CEST type=init
9:04AM INF Branch: support-for-running-integration-tests-locally type=init
9:04AM INF Commit: 8a54a12e667e00c2975b8885404dca5e0ac647dc type=init
9:04AM INF Content read count=0
9:04AM INF Starting HTTP server at ':8080'
9:04AM INF Initializing HTTP server at ':8080'
9:04AM INF API prefix is set to '/api/insights-results-aggregator/v2/'
9:04AM INF Server has been initiliazed
9:04AM INF Access REST API via: curl ptisnovs:8080/api/insights-results-aggregator/v2/
Building REST API tests utility
REST API tests build ok
{"status":"ok"}

For 12 requests made
  All tests passed
Exiting and killing all children...
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
