### PR TITLE
Ability to exit HTTP server gracefully for testing purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Mock service mimicking Insights Results Aggregator
         * [Response from the service](#response-from-the-service-2)
         * [Response in case of empty result set](#response-in-case-of-empty-result-set)
         * [Response in case of improper request](#response-in-case-of-improper-request)
+* [Debug endpoints](#debug-endpoints)
+    * [Exit HTTP server gracefully](#exit-http-server-gracefully)
 * [BDD tests](#bdd-tests)
 * [Package manifest](#package-manifest)
 
@@ -1046,6 +1048,23 @@ curl -v localhost:8080/api/insights-results-aggregator/v2/cluster/34c3ecc5-624a-
   "status": "invalid request ID: '38584huk209q82uhl8md5gsdxr_'"
 }
 ```
+
+## Debug endpoints
+
+The following endpoints needs to be enabled via configuration file by setting `debug` option to `true`.
+
+### Exit HTTP server gracefully
+
+Request to the service:
+
+```
+curl -X PUT -v localhost:8080/api/insights-results-aggregator/v2/exit
+```
+
+Response from the service:
+
+None, the server will stop immediatelly.
+
 
 
 ## BDD tests

--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=52
+threshold=55
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@
 address = ":8080"
 api_prefix = "/api/insights-results-aggregator/v2/"
 api_spec_file = "openapi.json"
+debug = true
 
 [content]
 path = "content.json"

--- a/config_container.toml
+++ b/config_container.toml
@@ -2,6 +2,7 @@
 address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "/openapi.json"
+debug = false
 
 [groups]
 path = "/groups_config.yaml"

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -122,6 +122,9 @@ const (
 
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
+
+	// ExitEndpoint perform server shutdown (in Debug mode only)
+	ExitEndpoint = "exit"
 )
 
 // MakeURLToEndpoint creates URL to endpoint, use constants from file endpoints.go

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Red Hat, Inc.
+Copyright © 2020, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -799,4 +801,9 @@ func (server *HTTPServer) readRuleHitsForRequestID(writer http.ResponseWriter, r
 	if err != nil {
 		log.Error().Err(err).Msg(responseDataError)
 	}
+}
+
+func (server *HTTPServer) exit(writer http.ResponseWriter, request *http.Request) {
+	server.Stop(context.Background())
+	os.Exit(0)
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -808,6 +808,9 @@ func (server *HTTPServer) exit(writer http.ResponseWriter, request *http.Request
 	if err != nil {
 		log.Error().Err(err).Msg(responseDataError)
 	}
-	server.Stop(context.Background())
+	err = server.Stop(context.Background())
+	if err != nil {
+		log.Error().Err(err).Msg("Error stopping HTTP server")
+	}
 	os.Exit(0)
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -804,6 +804,10 @@ func (server *HTTPServer) readRuleHitsForRequestID(writer http.ResponseWriter, r
 }
 
 func (server *HTTPServer) exit(writer http.ResponseWriter, request *http.Request) {
+	err := responses.SendOK(writer, responses.BuildOkResponse())
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
 	server.Stop(context.Background())
 	os.Exit(0)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,13 @@ func (server *HTTPServer) Initialize(address string) http.Handler {
 	router := mux.NewRouter().StrictSlash(true)
 
 	server.addEndpointsToRouter(router)
+
+	// Endpoints enabled in Debug mode only
+	if server.Config.Debug {
+		log.Info().Msg("Debug endpoints enabled")
+		server.addDebugEndpointsToRouter(router)
+	}
+
 	log.Info().Msgf("Server has been initiliazed")
 
 	return router
@@ -161,11 +168,15 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 
 	// OpenAPI specs
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)
+}
 
-	// Endpoints enabled in Debug mode only
-	if server.Config.Debug {
-		router.HandleFunc(apiPrefix+ExitEndpoint, server.exit).Methods(http.MethodPut)
+func (server *HTTPServer) addDebugEndpointsToRouter(router *mux.Router) {
+	apiPrefix := server.Config.APIPrefix
+	if !strings.HasSuffix(apiPrefix, "/") {
+		apiPrefix += "/"
 	}
+
+	router.HandleFunc(apiPrefix+ExitEndpoint, server.exit).Methods(http.MethodPut)
 }
 
 /*

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,11 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 
 	// OpenAPI specs
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)
+
+	// Endpoints enabled in Debug mode only
+	if server.Config.Debug {
+		router.HandleFunc(apiPrefix+ExitEndpoint, server.exit).Methods(http.MethodPut)
+	}
 }
 
 /*


### PR DESCRIPTION
# Description

Ability to exit HTTP server gracefully for testing purposes.
TL;DR; we need to be able to exit gracefully in order to measure code coverage by REST API tests.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update
- Configuration update

## Testing steps

1st terminal
```
$ ./insights-results-aggregator-mock 

10:54AM INF Version: 0.1 type=init
10:54AM INF Build time: Thu 27 Jul 2023 10:52:43 AM CEST type=init
10:54AM INF Branch: master type=init
10:54AM INF Commit: 6b607d14bc94c1511040cc45d566efa27ec4559f type=init
10:54AM INF Content read count=0
10:54AM INF Starting HTTP server at ':8080'
10:54AM INF Initializing HTTP server at ':8080'
10:54AM INF API prefix is set to '/api/insights-results-aggregator/v2/'
10:54AM INF Server has been initiliazed
10:54AM INF Access REST API via: curl localhost:8080/api/insights-results-aggregator/v2/
```

2nd terminal

```
$ curl -v -X PUT localhost:8080/api/insights-results-aggregator/v2/exit

*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> PUT /api/insights-results-aggregator/v2/exit HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Empty reply from server
* Connection #0 to host localhost left intact
curl: (52) Empty reply from server
```


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
