### PR TITLE
Fix: improper content-type for cluster report REST API endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -411,6 +411,8 @@ func (server *HTTPServer) readReportForClusters(writer http.ResponseWriter, requ
 }
 
 func (server *HTTPServer) readReportForOrganizationAndCluster(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set(contentType, appJSON)
+
 	organizationID, err := readOrganizationID(writer, request)
 	if err != nil {
 		// everything has been handled already


### PR DESCRIPTION
# Description

Fix: improper `content-type` for cluster report REST API endpoint

Fixes https://issues.redhat.com/browse/CCXDEV-11518

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Can be checked locally by starting this service and retrieve report:

```
ptisnovs@ptisnovs:~$ curl -v localhost:8080/api/insights-results-aggregator/v2/report/11789772/34c3ecc5-624a-49a5-bab8-4fdc5e51a266 |head
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/insights-results-aggregator/v2/report/11789772/34c3ecc5-624a-49a5-bab8-4fdc5e51a266 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Mon, 31 Jul 2023 08:44:10 GMT
< Transfer-Encoding: chunked
< 
{ [3965 bytes data]
100 17528    0 17528    {
0  "report": {
     "meta": {
       "count": 7,
       "last_checked_at": "2020-05-27T14:15:35Z"
     },
     "data": [
0      {
         "created_at": "2020-03-06T12:00:00Z",
         "description": "Clusteroperator is degraded when the installer pods are removed too soon during upgrade",
16.7M      0 --:--:-- --:--:-- --:--:-- 16.7M
ptisnovs@ptisnovs:~$ curl -v localhost:8080/api/insights-results-aggregator/v2/report/11789772/34c3ecc5-624a-49a5-bab8-4fdc5e51a266 |head
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/insights-results-aggregator/v2/report/11789772/34c3ecc5-624a-49a5-bab8-4fdc5e51a266 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Mon, 31 Jul 2023 08:44:10 GMT
< Transfer-Encoding: chunked
< 
{ [3965 bytes data]
100 17528    0 17528    {
0  "report": {
     "meta": {
       "count": 7,
       "last_checked_at": "2020-05-27T14:15:35Z"
     },
     "data": [
0      {
         "created_at": "2020-03-06T12:00:00Z",
         "description": "Clusteroperator is degraded when the installer pods are removed too soon during upgrade",
16.7M      0 --:--:-- --:--:-- --:--:-- 16.7M
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
