### PR TITLE
Fix: proper HTTP codes for REST API endpoint to retrieve cluster report

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -415,18 +415,19 @@ func (server *HTTPServer) readReportForOrganizationAndCluster(writer http.Respon
 
 	organizationID, err := readOrganizationID(writer, request)
 	if err != nil {
-		// everything has been handled already
+		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	clusterName, err := readClusterName(writer, request)
 	if err != nil {
-		// everything has been handled already
+		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	report, err := server.Storage.ReadReportForOrganizationAndCluster(organizationID, clusterName)
 	if err != nil {
+		writer.WriteHeader(http.StatusNotFound)
 		log.Error().Err(err).Msg(unableToReadReportErrorMessage)
 		handleServerError(err)
 		return

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -277,12 +277,12 @@ func (storage MemoryStorage) GetOrgIDByClusterID(cluster types.ClusterName) (typ
 	return types.OrgID(orgID), nil
 }
 
-func getReportForCluster(clusterName types.ClusterName) string {
+func getReportForCluster(clusterName types.ClusterName) (string, bool) {
 	report, ok := reports[string(clusterName)]
 	if !ok {
-		return ""
+		return "", false
 	}
-	return report
+	return report, true
 }
 
 // ReadReportForCluster reads result (health status) for selected cluster
@@ -322,7 +322,7 @@ func (storage MemoryStorage) ReadReportForCluster(
 		reportName = chooseReport(changingCluster)
 	}
 
-	report = getReportForCluster(reportName)
+	report, _ = getReportForCluster(reportName)
 
 	return types.ClusterReport(report), nil
 }
@@ -358,10 +358,13 @@ func (storage MemoryStorage) ReadReportForOrganizationAndCluster(
 	case 11940171:
 		return types.ClusterReport(report), errors.New(noPermissionsForOrg)
 	case 1, 2, 3, 11789772:
-		report = getReportForCluster(clusterName)
+		report, found := getReportForCluster(clusterName)
+		if found {
+			return types.ClusterReport(report), nil
+		}
 	}
 
-	return types.ClusterReport(report), nil
+	return types.ClusterReport(report), errors.New("Cluster not found")
 }
 
 // ReadReportForClusterByClusterName reads result (health status) for selected cluster for given organization


### PR DESCRIPTION
# Description

Fix: proper HTTP codes for REST API endpoint to retrieve cluster report

Fixes https://issues.redhat.com/browse/CCXDEV-11519

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Can be tested locally by providing unknown cluster, cluster name with improper format, organization with improper format etc.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
