### PR TITLE
REST API tests for endpoint to return recommendations for selected organization and clusted name

### DIFF
--- a/tests/rest/common.go
+++ b/tests/rest/common.go
@@ -46,6 +46,7 @@ const (
 	cluster1ForOrg1 = "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
 	cluster2ForOrg1 = "ee7d2bf4-8933-4a3a-8634-3328fe806e08"
 	cluster3ForOrg1 = "eeeeeeee-eeee-eeee-eeee-000000000001"
+	unknownCluster  = "ffffeeee-eeee-eeee-eeee-000000000001"
 )
 
 // StatusOnlyResponse represents response containing just a status

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -79,3 +79,15 @@ func checkReportForUnknownOrganization() {
 
 	f.PrintReport()
 }
+
+// checkReportForImproperOrganization checks how improperly entered
+// organization ID is checked by REST API handler
+func checkReportForImproperOrganization() {
+	url := fmt.Sprintf("%sreport/foobar/%s", apiURL, cluster1ForOrg1)
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(url)
+	f.Send()
+	f.ExpectStatus(http.StatusBadRequest)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -114,3 +114,15 @@ func checkReportForKnownOrganizationWrongCluster() {
 
 	f.PrintReport()
 }
+
+// checkWrongMethodsForReportEndpoint checks whether other HTTP methods are
+// rejected correctly for the REST API 'report' point
+func checkWrongMethodsForReportEndpoint() {
+	// known organizations
+	checkGetEndpointByOtherMethods(reportEndpoint(organization1, cluster1ForOrg1), false)
+	checkGetEndpointByOtherMethods(reportEndpoint(organization2, cluster1ForOrg1), false)
+
+	// unknown organizations
+	checkGetEndpointByOtherMethods(reportEndpoint(1, ""), false)
+	checkGetEndpointByOtherMethods(reportEndpoint(2, ""), false)
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -68,3 +68,14 @@ func checkReportForKnownOrganizationKnownCluster() {
 	}
 	f.PrintReport()
 }
+
+// checkReportForUknownOrganization checks how uknown organization ID is
+// checked by REST API handler
+func checkReportForUnknownOrganization() {
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(1234, unknownCluster))
+	f.Send()
+	f.ExpectStatus(http.StatusNotFound)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -91,3 +91,26 @@ func checkReportForImproperOrganization() {
 
 	f.PrintReport()
 }
+
+// checkReportForKnownOrganizationUnknownCluster checks how unknown cluster
+// name is checked by REST API handler
+func checkReportForKnownOrganizationUnknownCluster() {
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(organization1, unknownCluster))
+	f.Send()
+	f.ExpectStatus(http.StatusNotFound)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	f.PrintReport()
+}
+
+// checkReportForKnownOrganizationWrongCluster checks how improper cluster name
+// is checked by REST API handler
+func checkReportForKnownOrganizationWrongCluster() {
+	clusterName := "abcdefghijklmnopqrstuvwyz"
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(organization1, clusterName))
+	f.Send()
+	f.ExpectStatus(http.StatusBadRequest)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tests contains REST API tests for following endpoints:
+//
+// apiPrefix
+// apiPrefix + "clusters"
+// apiPrefix + "groups"
+// apiPrefix + "organizations"
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/verdverm/frisby"
+
+	"github.com/RedHatInsights/insights-results-aggregator-mock/types"
+)
+
+// FullReportResponse represents response containing report for given cluster
+type FullReportResponse struct {
+	Report types.ReportResponse `json:"report"`
+	Status string               `json:"status"`
+}
+
+// reportEndpoint helper function constructs URL for accessing endpoint to
+// retrieve report for given organization and cluster
+func reportEndpoint(orgID int, clusterName string) string {
+	return fmt.Sprintf("%sreport/%d/%s", apiURL, orgID, clusterName)
+}
+
+// checkReportForKnownOrganization checks if proper report is returned for
+// known organization ID and known cluster name
+func checkReportForKnownOrganizationKnownCluster() {
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(organization1, cluster1ForOrg1))
+	f.Send()
+	f.ExpectStatus(http.StatusOK)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	// check the response
+	text, err := f.Resp.Content()
+	if err != nil {
+		f.AddError(err.Error())
+	} else {
+		response := FullReportResponse{}
+		err := json.Unmarshal(text, &response)
+		if err != nil {
+			f.AddError(err.Error())
+		}
+		if response.Status != "ok" {
+			f.AddError(statusShouldBeSetToOK)
+		}
+	}
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,7 +47,7 @@ func reportEndpoint(orgID int, clusterName string) string {
 // checkReportForKnownOrganization checks if proper report is returned for
 // known organization ID and known cluster name
 func checkReportForKnownOrganizationKnownCluster() {
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(organization1, cluster1ForOrg1))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with known cluster").Get(reportEndpoint(organization1, cluster1ForOrg1))
 	f.Send()
 	f.ExpectStatus(http.StatusOK)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -72,7 +72,7 @@ func checkReportForKnownOrganizationKnownCluster() {
 // checkReportForUknownOrganization checks how uknown organization ID is
 // checked by REST API handler
 func checkReportForUnknownOrganization() {
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(1234, unknownCluster))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown organization").Get(reportEndpoint(1234, unknownCluster))
 	f.Send()
 	f.ExpectStatus(http.StatusNotFound)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -84,7 +84,7 @@ func checkReportForUnknownOrganization() {
 // organization ID is checked by REST API handler
 func checkReportForImproperOrganization() {
 	url := fmt.Sprintf("%sreport/foobar/%s", apiURL, cluster1ForOrg1)
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(url)
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with improper organization ID").Get(url)
 	f.Send()
 	f.ExpectStatus(http.StatusBadRequest)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -95,7 +95,7 @@ func checkReportForImproperOrganization() {
 // checkReportForKnownOrganizationUnknownCluster checks how unknown cluster
 // name is checked by REST API handler
 func checkReportForKnownOrganizationUnknownCluster() {
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(organization1, unknownCluster))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown cluster").Get(reportEndpoint(organization1, unknownCluster))
 	f.Send()
 	f.ExpectStatus(http.StatusNotFound)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -107,7 +107,7 @@ func checkReportForKnownOrganizationUnknownCluster() {
 // is checked by REST API handler
 func checkReportForKnownOrganizationWrongCluster() {
 	clusterName := "abcdefghijklmnopqrstuvwyz"
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method").Get(reportEndpoint(organization1, clusterName))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with improper cluster name").Get(reportEndpoint(organization1, clusterName))
 	f.Send()
 	f.ExpectStatus(http.StatusBadRequest)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)

--- a/tests/rest/rest.go
+++ b/tests/rest/rest.go
@@ -48,4 +48,11 @@ func BasicTests() {
 	checkClustersEndpointForOrganization2()
 	checkWrongMethodsForClustersEndpoint()
 
+	// implementation of these tests is stored in reports.go
+	checkReportForKnownOrganizationKnownCluster()
+	checkReportForUnknownOrganization()
+	checkReportForImproperOrganization()
+	checkReportForKnownOrganizationUnknownCluster()
+	checkReportForKnownOrganizationWrongCluster()
+	checkWrongMethodsForReportEndpoint()
 }

--- a/types/types.go
+++ b/types/types.go
@@ -78,7 +78,7 @@ type RuleContentResponse struct {
 	CreatedAt    string      `json:"created_at"`
 	Description  string      `json:"description"`
 	ErrorKey     string      `json:"-"`
-	Generic      string      `json:"details"`
+	Generic      interface{} `json:"details"`
 	Reason       string      `json:"reason"`
 	Resolution   string      `json:"resolution"`
 	TotalRisk    int         `json:"total_risk"`


### PR DESCRIPTION
# Description

REST API tests for endpoint to return recommendations for selected organization and clusted name

## Type of change

- REST API tests

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
