### PR TITLE
Use named constants for HTTP codes in REST API tests

### DIFF
--- a/tests/rest/clusters.go
+++ b/tests/rest/clusters.go
@@ -25,6 +25,7 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/verdverm/frisby"
 )
@@ -57,7 +58,7 @@ func testClusterIDExistence(f *frisby.Frisby, clusters []string, searchedCluster
 func checkClustersEndpointForOrganization1() {
 	f := frisby.Create("Check the 'clusters' REST API point using HTTP GET method").Get(clustersEndpointForOrganization(organization1))
 	f.Send()
-	f.ExpectStatus(200)
+	f.ExpectStatus(http.StatusOK)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	// check the response
@@ -89,7 +90,7 @@ func checkClustersEndpointForOrganization1() {
 func checkClustersEndpointForOrganization2() {
 	f := frisby.Create("Check the 'clusters' REST API point using HTTP GET method").Get(clustersEndpointForOrganization(organization2))
 	f.Send()
-	f.ExpectStatus(403)
+	f.ExpectStatus(http.StatusForbidden)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	// check the response

--- a/tests/rest/common.go
+++ b/tests/rest/common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tests
 
 import (
+	"net/http"
+
 	"github.com/verdverm/frisby"
 )
 
@@ -64,23 +66,23 @@ func sendAndExpectStatus(f *frisby.Frisby, expectedStatus int) {
 // checkGetEndpointByOtherMethods checks whether a 'GET' endpoint respond correctly if other HTTP methods are used
 func checkGetEndpointByOtherMethods(endpoint string, includingOptions bool) {
 	f := frisby.Create("Check the end point " + endpoint + " with wrong method: POST").Post(endpoint)
-	sendAndExpectStatus(f, 405)
+	sendAndExpectStatus(f, http.StatusMethodNotAllowed)
 
 	f = frisby.Create("Check the entry point " + endpoint + " with wrong method: PUT").Put(endpoint)
-	sendAndExpectStatus(f, 405)
+	sendAndExpectStatus(f, http.StatusMethodNotAllowed)
 
 	f = frisby.Create("Check the entry point " + endpoint + " with wrong method: DELETE").Delete(endpoint)
-	sendAndExpectStatus(f, 405)
+	sendAndExpectStatus(f, http.StatusMethodNotAllowed)
 
 	f = frisby.Create("Check the entry point " + endpoint + " with wrong method: PATCH").Patch(endpoint)
-	sendAndExpectStatus(f, 405)
+	sendAndExpectStatus(f, http.StatusMethodNotAllowed)
 
 	f = frisby.Create("Check the entry point " + endpoint + " with wrong method: HEAD").Head(endpoint)
-	sendAndExpectStatus(f, 405)
+	sendAndExpectStatus(f, http.StatusMethodNotAllowed)
 
 	// some endpoints accepts OPTIONS method together with GET one, so this check is fully optional
 	if includingOptions {
 		f = frisby.Create("Check the entry point " + endpoint + " with wrong method: OPTIONS").Options(endpoint)
-		sendAndExpectStatus(f, 405)
+		sendAndExpectStatus(f, http.StatusMethodNotAllowed)
 	}
 }

--- a/tests/rest/entrypoint.go
+++ b/tests/rest/entrypoint.go
@@ -24,6 +24,7 @@ package tests
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/verdverm/frisby"
 )
@@ -32,7 +33,7 @@ import (
 func checkRestAPIEntryPoint() {
 	f := frisby.Create("Check the entry point to REST API using HTTP GET method").Get(apiURL)
 	f.Send()
-	f.ExpectStatus(200)
+	f.ExpectStatus(http.StatusOK)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	// check the response
@@ -56,7 +57,7 @@ func checkRestAPIEntryPoint() {
 func checkNonExistentEntryPoint() {
 	f := frisby.Create("Check the non-existent entry point to REST API").Get(apiURL + "foobar")
 	f.Send()
-	f.ExpectStatus(404)
+	f.ExpectStatus(http.StatusNotFound)
 	f.ExpectHeader(contentTypeHeader, ContentTypeText)
 	f.PrintReport()
 }
@@ -67,7 +68,7 @@ func checkWrongEntryPoint() {
 	for _, postfix := range postfixes {
 		f := frisby.Create("Check the wrong entry point to REST API with postfix '" + postfix + "'").Get(apiURL + postfix)
 		f.Send()
-		f.ExpectStatus(404)
+		f.ExpectStatus(http.StatusNotFound)
 		f.ExpectHeader(contentTypeHeader, ContentTypeText)
 		f.PrintReport()
 	}

--- a/tests/rest/groups.go
+++ b/tests/rest/groups.go
@@ -24,6 +24,7 @@ package tests
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/verdverm/frisby"
 )
@@ -47,7 +48,7 @@ type GroupsResponse struct {
 func checkGroupsEndpoint() {
 	f := frisby.Create("Check the 'groups' REST API point using HTTP GET method").Get(apiURL + groupsEndpointPostfix)
 	f.Send()
-	f.ExpectStatus(200)
+	f.ExpectStatus(http.StatusOK)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	// check the response

--- a/tests/rest/organizations.go
+++ b/tests/rest/organizations.go
@@ -25,6 +25,7 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/verdverm/frisby"
 )
@@ -53,7 +54,7 @@ func testOrganizationIDExistence(f *frisby.Frisby, organizations []int, organiza
 func checkOrganizationsEndpoint() {
 	f := frisby.Create("Check the 'organizations' REST API point using HTTP GET method").Get(apiURL + organizationsEndpointPostfix)
 	f.Send()
-	f.ExpectStatus(200)
+	f.ExpectStatus(http.StatusOK)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	// check the response


### PR DESCRIPTION
# Description

Use named constants for HTTP codes in REST API tests

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
