### PR TITLE
REST API tests for endpoint to retrieve cluster report without specifying org ID

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -309,6 +309,7 @@ func (server *HTTPServer) readReportForCluster(writer http.ResponseWriter, reque
 		handleServerError(err)
 		return
 	}
+	writer.Header().Set(contentType, appJSON)
 
 	r := []byte(report)
 	_, err = writer.Write(r)

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -158,3 +158,13 @@ func checkReportForKnownCluster() {
 	}
 	f.PrintReport()
 }
+
+// checkReportForUnknownCluster checks how unknown cluster
+// name is checked by REST API handler
+func checkReportForUnknownCluster() {
+	url := reportEndpointForCluster(unknownCluster)
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown cluster w/o org").Get(url)
+	f.Send()
+	f.ExpectStatus(http.StatusNotFound)
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -178,3 +178,10 @@ func checkReportForImproperCluster() {
 	f.ExpectStatus(http.StatusBadRequest)
 	f.PrintReport()
 }
+
+// checkWrongMethodsForClusterReportEndpoint checks whether other HTTP methods are
+// rejected correctly for the REST API 'report' point
+func checkWrongMethodsForClusterReportEndpoint() {
+	checkGetEndpointByOtherMethods(reportEndpointForCluster(cluster1ForOrg1), false)
+	checkGetEndpointByOtherMethods(reportEndpointForCluster(cluster1ForOrg1), false)
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -168,3 +168,13 @@ func checkReportForUnknownCluster() {
 	f.ExpectStatus(http.StatusNotFound)
 	f.PrintReport()
 }
+
+// checkReportForImproperCluster checks how improper cluster
+// name is checked by REST API handler
+func checkReportForImproperCluster() {
+	url := reportEndpointForCluster("foobarbaz")
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with improper cluster w/o org").Get(url)
+	f.Send()
+	f.ExpectStatus(http.StatusBadRequest)
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -132,3 +132,29 @@ func checkWrongMethodsForReportForOrgAndClusterEndpoint() {
 	checkGetEndpointByOtherMethods(reportEndpointForOrgAndCluster(1, ""), false)
 	checkGetEndpointByOtherMethods(reportEndpointForOrgAndCluster(2, ""), false)
 }
+
+// checkReportForKnownCluster checks if proper report is returned for
+// known cluster name (w/o organization ID)
+func checkReportForKnownCluster() {
+	url := reportEndpointForCluster(cluster1ForOrg1)
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with known cluster w/o org").Get(url)
+	f.Send()
+	f.ExpectStatus(http.StatusOK)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	// check the response
+	text, err := f.Resp.Content()
+	if err != nil {
+		f.AddError(err.Error())
+	} else {
+		response := FullReportResponse{}
+		err := json.Unmarshal(text, &response)
+		if err != nil {
+			f.AddError(err.Error())
+		}
+		if response.Status != "ok" {
+			f.AddError(statusShouldBeSetToOK)
+		}
+	}
+	f.PrintReport()
+}

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -38,16 +38,22 @@ type FullReportResponse struct {
 	Status string               `json:"status"`
 }
 
-// reportEndpoint helper function constructs URL for accessing endpoint to
+// reportEndpointForCluster helper function constructs URL for accessing endpoint to
+// retrieve report for given cluster (w/o organization ID)
+func reportEndpointForCluster(clusterName string) string {
+	return fmt.Sprintf("%sreport/%s", apiURL, clusterName)
+}
+
+// reportEndpointForOrgAndCluster helper function constructs URL for accessing endpoint to
 // retrieve report for given organization and cluster
-func reportEndpoint(orgID int, clusterName string) string {
+func reportEndpointForOrgAndCluster(orgID int, clusterName string) string {
 	return fmt.Sprintf("%sreport/%d/%s", apiURL, orgID, clusterName)
 }
 
-// checkReportForKnownOrganization checks if proper report is returned for
+// checkReportForKnownOrganizationKnownCluster checks if proper report is returned for
 // known organization ID and known cluster name
 func checkReportForKnownOrganizationKnownCluster() {
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with known cluster").Get(reportEndpoint(organization1, cluster1ForOrg1))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with known cluster").Get(reportEndpointForOrgAndCluster(organization1, cluster1ForOrg1))
 	f.Send()
 	f.ExpectStatus(http.StatusOK)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -72,7 +78,7 @@ func checkReportForKnownOrganizationKnownCluster() {
 // checkReportForUknownOrganization checks how uknown organization ID is
 // checked by REST API handler
 func checkReportForUnknownOrganization() {
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown organization").Get(reportEndpoint(1234, unknownCluster))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown organization").Get(reportEndpointForOrgAndCluster(1234, unknownCluster))
 	f.Send()
 	f.ExpectStatus(http.StatusNotFound)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -95,7 +101,7 @@ func checkReportForImproperOrganization() {
 // checkReportForKnownOrganizationUnknownCluster checks how unknown cluster
 // name is checked by REST API handler
 func checkReportForKnownOrganizationUnknownCluster() {
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown cluster").Get(reportEndpoint(organization1, unknownCluster))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with unknown cluster").Get(reportEndpointForOrgAndCluster(organization1, unknownCluster))
 	f.Send()
 	f.ExpectStatus(http.StatusNotFound)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -107,7 +113,7 @@ func checkReportForKnownOrganizationUnknownCluster() {
 // is checked by REST API handler
 func checkReportForKnownOrganizationWrongCluster() {
 	clusterName := "abcdefghijklmnopqrstuvwyz"
-	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with improper cluster name").Get(reportEndpoint(organization1, clusterName))
+	f := frisby.Create("Check the 'report' REST API point using HTTP GET method with improper cluster name").Get(reportEndpointForOrgAndCluster(organization1, clusterName))
 	f.Send()
 	f.ExpectStatus(http.StatusBadRequest)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -115,14 +121,14 @@ func checkReportForKnownOrganizationWrongCluster() {
 	f.PrintReport()
 }
 
-// checkWrongMethodsForReportEndpoint checks whether other HTTP methods are
+// checkWrongMethodsForReportForOrgAndClusterEndpoint checks whether other HTTP methods are
 // rejected correctly for the REST API 'report' point
-func checkWrongMethodsForReportEndpoint() {
+func checkWrongMethodsForReportForOrgAndClusterEndpoint() {
 	// known organizations
-	checkGetEndpointByOtherMethods(reportEndpoint(organization1, cluster1ForOrg1), false)
-	checkGetEndpointByOtherMethods(reportEndpoint(organization2, cluster1ForOrg1), false)
+	checkGetEndpointByOtherMethods(reportEndpointForOrgAndCluster(organization1, cluster1ForOrg1), false)
+	checkGetEndpointByOtherMethods(reportEndpointForOrgAndCluster(organization2, cluster1ForOrg1), false)
 
 	// unknown organizations
-	checkGetEndpointByOtherMethods(reportEndpoint(1, ""), false)
-	checkGetEndpointByOtherMethods(reportEndpoint(2, ""), false)
+	checkGetEndpointByOtherMethods(reportEndpointForOrgAndCluster(1, ""), false)
+	checkGetEndpointByOtherMethods(reportEndpointForOrgAndCluster(2, ""), false)
 }

--- a/tests/rest/rest.go
+++ b/tests/rest/rest.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Red Hat, Inc.
+Copyright © 2020, 2021, 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,5 +54,10 @@ func BasicTests() {
 	checkReportForImproperOrganization()
 	checkReportForKnownOrganizationUnknownCluster()
 	checkReportForKnownOrganizationWrongCluster()
-	checkWrongMethodsForReportEndpoint()
+	checkWrongMethodsForReportForOrgAndClusterEndpoint()
+
+	checkReportForKnownCluster()
+	checkReportForUnknownCluster()
+	checkReportForImproperCluster()
+	checkWrongMethodsForClusterReportEndpoint()
 }


### PR DESCRIPTION
# Description

- REST API tests for endpoint to retrieve cluster report without specifying org ID
- bug fix (wrong content/type for this endpoint)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- REST API tests

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
