### PR TITLE
DVO-related endpoint: list all namespaces

### DIFF
--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=52
+threshold=55
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -15,3 +15,57 @@ limitations under the License.
 */
 
 package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+// allDVONamespaces handler returns list of all DVO namespaces. Currently it
+// does not depend on Organization ID as this information is passed through
+// Bearer token in real Smart Proxy service. The format of output should be:
+//
+//           {
+//             "status": "ok",
+//             "workloads": [
+//                 {
+//                     "cluster": {
+//                         "uuid": "{cluster UUID}",
+//                         "display_name": "{cluster UUID or displayable name}",
+//                     },
+//                     "namespace": {
+//                         "uuid": "{namespace UUID}",
+//                         "name": "{namespace real name}", // optional, might be null
+//                     },
+//                     "reports": [
+//                         {
+//                             "check": "{for example no_anti_affinity}", // taken from the original full name deploment_validation_operator_no_anti_affinity
+//                             "kind": "{kind attribute}",
+//                             "description": {description}",
+//                             "remediation": {remediation}",
+//                         },
+//                     ]
+//             ]
+//         }
+func (server *HTTPServer) allDVONamespaces(writer http.ResponseWriter, request *http.Request) {
+	log.Info().Msg("All DVO namespaces handler")
+
+	// prepare response structure
+	var responseData AllDVONamespacesResponse
+	responseData.Status = "ok"
+
+	// transform response structure into proper JSON payload
+	bytes, err := json.MarshalIndent(responseData, "", "\t")
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+		return
+	}
+
+	// and send the response to client
+	_, err = writer.Write(bytes)
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -29,6 +29,33 @@ type AllDVONamespacesResponse struct {
 	Workloads []Workload `json:"workloads"`
 }
 
+// Workload structure represents one workload entry in list of workloads
+type Workload struct {
+	ClusterEntry ClusterEntry   `json:"cluster"`
+	Namespace    NamespaceEntry `json:"namespace"`
+	Reports      []DVOReport    `json:"reports"`
+}
+
+// ClusterEntry structure contains cluster UUID and cluster name
+type ClusterEntry struct {
+	UUID        string `json:"uuid"`
+	DisplayName string `json:"display_name"`
+}
+
+// Namespace structure contains basic information about namespace
+type NamespaceEntry struct {
+	UUID     string `json:"uuid"`
+	FullName string `json:"name"`
+}
+
+// DVOReport structure represents one DVO-related report
+type DVOReport struct {
+	Check       string `json:"check"`
+	Kind        string `json:"kind"`
+	Description string `json:"description"`
+	Remediation string `json:"remediation"`
+}
+
 // allDVONamespaces handler returns list of all DVO namespaces. Currently it
 // does not depend on Organization ID as this information is passed through
 // Bearer token in real Smart Proxy service. The format of output should be:

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -23,6 +23,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// AllDVONamespacesResponse is a data structure that represents list of namespace
+type AllDVONamespacesResponse struct {
+	Status    string     `json:"status"`
+	Workloads []Workload `json:"workloads"`
+}
+
 // allDVONamespaces handler returns list of all DVO namespaces. Currently it
 // does not depend on Organization ID as this information is passed through
 // Bearer token in real Smart Proxy service. The format of output should be:

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -42,7 +42,7 @@ type ClusterEntry struct {
 	DisplayName string `json:"display_name"`
 }
 
-// Namespace structure contains basic information about namespace
+// NamespaceEntry structure contains basic information about namespace
 type NamespaceEntry struct {
 	UUID     string `json:"uuid"`
 	FullName string `json:"name"`
@@ -60,28 +60,28 @@ type DVOReport struct {
 // does not depend on Organization ID as this information is passed through
 // Bearer token in real Smart Proxy service. The format of output should be:
 //
-//           {
-//             "status": "ok",
-//             "workloads": [
-//                 {
-//                     "cluster": {
-//                         "uuid": "{cluster UUID}",
-//                         "display_name": "{cluster UUID or displayable name}",
-//                     },
-//                     "namespace": {
-//                         "uuid": "{namespace UUID}",
-//                         "name": "{namespace real name}", // optional, might be null
-//                     },
-//                     "reports": [
-//                         {
-//                             "check": "{for example no_anti_affinity}", // taken from the original full name deploment_validation_operator_no_anti_affinity
-//                             "kind": "{kind attribute}",
-//                             "description": {description}",
-//                             "remediation": {remediation}",
-//                         },
-//                     ]
-//             ]
-//         }
+//	  {
+//	    "status": "ok",
+//	    "workloads": [
+//	        {
+//	            "cluster": {
+//	                "uuid": "{cluster UUID}",
+//	                "display_name": "{cluster UUID or displayable name}",
+//	            },
+//	            "namespace": {
+//	                "uuid": "{namespace UUID}",
+//	                "name": "{namespace real name}", // optional, might be null
+//	            },
+//	            "reports": [
+//	                {
+//	                    "check": "{for example no_anti_affinity}", // taken from the original full name deploment_validation_operator_no_anti_affinity
+//	                    "kind": "{kind attribute}",
+//	                    "description": {description}",
+//	                    "remediation": {remediation}",
+//	                },
+//	            ]
+//	    ]
+//	}
 func (server *HTTPServer) allDVONamespaces(writer http.ResponseWriter, request *http.Request) {
 	log.Info().Msg("All DVO namespaces handler")
 

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -88,6 +88,32 @@ func (server *HTTPServer) allDVONamespaces(writer http.ResponseWriter, request *
 	// prepare response structure
 	var responseData AllDVONamespacesResponse
 	responseData.Status = "ok"
+	responseData.Workloads = []Workload{
+		Workload{
+			ClusterEntry{
+				UUID:        "00000001-0001-0001-0001-000000000001",
+				DisplayName: "Cluster #1",
+			},
+			NamespaceEntry{
+				UUID:     "00000002-0002-0002-0002-000000000002",
+				FullName: "Namespace #2",
+			},
+			[]DVOReport{
+				DVOReport{
+					Check:       "no_anti_affinity",
+					Kind:        "Deployment",
+					Description: "Indicates when... ... ...",
+					Remediation: "Specify anti-affinity in your pod specification ... ... ...",
+				},
+				DVOReport{
+					Check:       "run_as_non_root",
+					Kind:        "Runtime",
+					Description: "Indicates when... ... ...",
+					Remediation: "Select different user to run this deployment... ... ...",
+				},
+			},
+		},
+	}
 
 	// transform response structure into proper JSON payload
 	bytes, err := json.MarshalIndent(responseData, "", "\t")

--- a/server/server.go
+++ b/server/server.go
@@ -166,6 +166,9 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	// for more information about this endpoint
 	router.HandleFunc(apiPrefix+UpgradeRisksPredictionEndpoint, server.upgradeRisksPrediction).Methods(http.MethodGet)
 
+	// DVO-related endpoints
+	router.HandleFunc(apiPrefix+AllDVONamespaces, server.allDVONamespaces).Methods(http.MethodGet)
+
 	// OpenAPI specs
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)
 }


### PR DESCRIPTION
# Description

- DVO-related endpoint: list all namespaces
- Usage
```
$ curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo | jq .
{
  "status": "ok",
  "workloads": [
    {
      "cluster": {
        "uuid": "00000001-0001-0001-0001-000000000001",
        "display_name": "Cluster #1"
      },
      "namespace": {
        "uuid": "00000002-0002-0002-0002-000000000002",
        "name": "Namespace #2"
      },
      "reports": [
        {
          "check": "no_anti_affinity",
          "kind": "Deployment",
          "description": "Indicates when... ... ...",
          "remediation": "Specify anti-affinity in your pod specification ... ... ..."
        },
        {
          "check": "run_as_non_root",
          "kind": "Runtime",
          "description": "Indicates when... ... ...",
          "remediation": "Select different user to run this deployment... ... ..."
        }
      ]
    }
  ]
}

```

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

See above

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
