### PR TITLE
Proper content-type for read multiple clusters results endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -380,6 +380,10 @@ func (server *HTTPServer) readReportForClusters(writer http.ResponseWriter, requ
 		return
 	}
 
+	// server response has JSON format for this endpoint
+	writer.Header().Set(contentType, appJSON)
+
+	// construct reports for all clusters in a list
 	for _, clusterName := range clusterList.Clusters {
 		log.Info().Str("cluster name", clusterName).Msg("result for cluster")
 		clusterName := types.ClusterName(clusterName)
@@ -401,11 +405,15 @@ func (server *HTTPServer) readReportForClusters(writer http.ResponseWriter, requ
 		generatedReports.ClusterList = append(generatedReports.ClusterList, clusterName)
 		generatedReports.Reports[clusterName] = report
 	}
+
+	// try to serialize all reports
 	bytes, err := json.MarshalIndent(generatedReports, "", "\t")
 	if err != nil {
 		log.Error().Err(err).Msg(responseDataError)
 		return
 	}
+
+	// send report back to client
 	_, err = writer.Write(bytes)
 	if err != nil {
 		log.Error().Err(err).Msg(responseDataError)


### PR DESCRIPTION
# Description

Proper content-type for read multiple clusters results endpoint

Fixes https://issues.redhat.com/browse/CCXDEV-11697

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
