### PR TITLE
[CCXDEV-10937] Update Travis BDD step to use run_in_container.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,11 @@ jobs:
         - ./test.sh
     - stage: bdd tests
       before_script:
-        - wget -O docker-compose.yml https://raw.githubusercontent.com/RedHatInsights/insights-behavioral-spec/main/docker-compose.yml
-        - POSTGRES_DB_NAME=test docker-compose up -d
-        - cid=$(docker ps | grep 'insights-behavioral-spec:latest' | cut -d ' ' -f 1)
         - make build
-        - docker cp . $cid:`docker exec $cid bash -c 'echo "$HOME"'`/mock_server
-        - docker cp insights-results-aggregator-mock $cid:`docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"'`
-        - docker exec -u root $cid /bin/bash -c 'chmod +x $VIRTUAL_ENV_BIN/insights-results-aggregator-mock'
+        - wget -O docker-compose.yml https://raw.githubusercontent.com/RedHatInsights/insights-behavioral-spec/main/docker-compose.yml
+        - wget -O bdd_runner.sh https://raw.githubusercontent.com/RedHatInsights/insights-behavioral-spec/main/run_in_docker.sh && chmod +x bdd_runner.sh
       script:
-        - docker exec -it $cid /bin/bash -c 'export PATH_TO_MOCK_SERVER=$HOME/mock_server && env && make aggregator-mock-tests'
+        - ./bdd_runner.sh aggregator-mock-tests .
 
 stages:
   - build


### PR DESCRIPTION
# Description

Simplify BDD stage in Travis by using the [run_in_container.sh script](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/run_in_docker.sh).

Fixes CCXDEV-10937

## Type of change

- Refactor (refactoring code, removing useless files)
- Behavioral tests (no changes in the code)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
