### PR TITLE
Don't build service binary for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo ##
 run: clean build ## Build the project and executes the binary
 	./insights-results-aggregator-mock
 
-test: clean build ## Run the unit tests
+test: ## Run the unit tests
 	@go test -coverprofile coverage.out $(shell go list ./... | grep -v tests)
 	@go tool cover -func=coverage.out
 


### PR DESCRIPTION
# Description

- Don't build service binary for unit tests
- Speedup local development

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

Even on CI it should be visible change.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
