### PR TITLE
REST API endpoint implementation for DVO recommendations for DVO cluster and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Mock service mimicking Insights Results Aggregator
     * [List of all DVO namespaces](#list-of-all-dvo-namespaces)
         * [Request to the service](#request-to-the-service)
         * [Response from the service](#response-from-the-service-3)
+    * [DVO Recommendations for selected cluster and namespace](#dvo-recommendations-for-selected-cluster-and-namespace)
 * [Debug endpoints](#debug-endpoints)
     * [Exit HTTP server gracefully](#exit-http-server-gracefully)
 * [Definition of Done for new features and fixes](#definition-of-done-for-new-features-and-fixes)
@@ -1102,6 +1103,21 @@ curl -v localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
     }
   ]
 }
+```
+
+### DVO Recommendations for selected cluster and namespace
+
+Returns recommendations for selected cluster and namespace.
+
+Request:
+```
+curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo/{namespace_uuid}/cluster/{cluster_uuid}
+```
+
+Example with data:
+
+```
+curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo/fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f/cluster/00000001-0001-0001-0001-000000000002
 ```
 
 ## Debug endpoints

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -296,7 +296,7 @@ func getNamespaces(workloads []types.DVOWorkload) []string {
 
 	// convert map to slice of keys.
 	keys := []string{}
-	for key, _ := range namespaces {
+	for key := range namespaces {
 		keys = append(keys, key)
 	}
 

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -42,6 +42,11 @@ type Workload struct {
 	MetadataEntry MetadataEntry  `json:"metadata"`
 }
 
+// WorkloadsForCluster structure represents workload for one selected cluster
+type WorkloadsForCluster struct {
+	Status string `json:"status"`
+}
+
 // ClusterEntry structure contains cluster UUID and cluster name
 type ClusterEntry struct {
 	UUID        string `json:"uuid"`
@@ -233,6 +238,26 @@ func (server *HTTPServer) dvoNamespaceForCluster(writer http.ResponseWriter, req
 			log.Error().Err(err).Msg(responseDataError)
 		}
 		return
+	}
+
+	// set the response header
+	writer.Header().Set(contentType, appJSON)
+
+	// prepare response structure
+	var responseData WorkloadsForCluster
+	responseData.Status = "ok"
+
+	// transform response structure into proper JSON payload
+	bytes, err := json.MarshalIndent(responseData, "", "\t")
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+		return
+	}
+
+	// and send the response to client
+	_, err = writer.Write(bytes)
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
 	}
 }
 

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -44,9 +44,10 @@ type Workload struct {
 
 // WorkloadsForCluster structure represents workload for one selected cluster
 type WorkloadsForCluster struct {
-	Status       string         `json:"status"`
-	ClusterEntry ClusterEntry   `json:"cluster"`
-	Namespace    NamespaceEntry `json:"namespace"`
+	Status        string         `json:"status"`
+	ClusterEntry  ClusterEntry   `json:"cluster"`
+	Namespace     NamespaceEntry `json:"namespace"`
+	MetadataEntry MetadataEntry  `json:"metadata"`
 }
 
 // ClusterEntry structure contains cluster UUID and cluster name
@@ -236,7 +237,7 @@ func (server *HTTPServer) dvoNamespaceForCluster(writer http.ResponseWriter, req
 	}
 	log.Info().Str("namespace selector", namespace).Msg("Query parameters")
 
-	_, found := data.DVOWorkloads[types.ClusterName(cluster)]
+	workloadsForCluster, found := data.DVOWorkloads[types.ClusterName(cluster)]
 	if !found {
 		message := fmt.Sprintf("DVO namespaces for cluster %s not found", cluster)
 		log.Info().Msg(message)
@@ -262,6 +263,13 @@ func (server *HTTPServer) dvoNamespaceForCluster(writer http.ResponseWriter, req
 	responseData.Namespace = NamespaceEntry{
 		UUID:     namespace,
 		FullName: "Namespace name " + namespace,
+	}
+	responseData.MetadataEntry = MetadataEntry{
+		Recommendations: numberOfRecommendations(workloadsForCluster, namespace),
+		Objects:         numberOfObjects(workloadsForCluster, namespace),
+		ReportedAt:      time.Now().Format(time.RFC3339),
+		LastCheckedAt:   time.Now().Format(time.RFC3339),
+		HighestSeverity: 5,
 	}
 
 	// transform response structure into proper JSON payload

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -153,7 +153,7 @@ const (
 	// - Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper cluster UUID
 	// - Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper organization
 	//
-	DVONamespaceForCluster1 = "cluster/{cluster_name}/namespaces/dvo"
+	DVONamespaceForCluster1 = "cluster/{cluster_name}/namespaces/dvo/{namespace}"
 
 	// DVONamespaceForCluster2 endpoint address.
 	//
@@ -169,7 +169,7 @@ const (
 	// - Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper organization
 	// - Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces when cluster is not specified
 	//
-	DVONamespaceForCluster2 = "namespaces/dvo/cluster/{cluster_name}"
+	DVONamespaceForCluster2 = "namespaces/dvo/{namespace}/cluster/{cluster_name}"
 
 	// DVONamespaceInfo endpoint address.
 	//

--- a/server/server.go
+++ b/server/server.go
@@ -174,6 +174,8 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	// DVONamespaceInfo = "namespaces/dvo/{namespace_id}/info"
 	// DVONamespaceReports = "namespaces/dvo/{namespace_id}/reports"
 	router.HandleFunc(apiPrefix+AllDVONamespaces, server.allDVONamespaces).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+DVONamespaceForCluster1, server.dvoNamespaceForCluster).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+DVONamespaceForCluster2, server.dvoNamespaceForCluster).Methods(http.MethodGet)
 
 	// OpenAPI specs
 	router.HandleFunc(openAPIURL, server.serveAPISpecFile).Methods(http.MethodGet)


### PR DESCRIPTION
# Description

REST API endpoint implementation for DVO recommendations for DVO cluster and namespace

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

It's easy:
```
curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo/fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f/cluster/00000001-0001-0001-0001-000000000002| jq .
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
