### PR TITLE
fix highest severity (1-4); add hits by severity to DVO endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,13 @@ curl -v localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
         "objects": 3,
         "reported_at": "2023-10-05T07:37:59+02:00",
         "last_checked_at": "2023-10-05T07:37:59+02:00",
-        "highest_severity": 5
+        "highest_severity": 4,
+        "hits_by_severity": {
+          "1": 0,
+          "2": 2,
+          "3": 0,
+          "4": 1
+        }
       }
     },
     {
@@ -1111,7 +1117,13 @@ curl -v localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo
         "objects": 2,
         "reported_at": "2023-10-05T07:37:59+02:00",
         "last_checked_at": "2023-10-05T07:37:59+02:00",
-        "highest_severity": 5
+        "highest_severity": 3,
+        "hits_by_severity": {
+          "1": 0,
+          "2": 0,
+          "3": 1,
+          "4": 0
+        }
       }
     },
     ...
@@ -1165,7 +1177,13 @@ curl localhost:8080/api/insights-results-aggregator/v2/namespaces/dvo/fbcbe2d3-e
     "objects": 3,
     "reported_at": "2023-10-05T07:38:51+02:00",
     "last_checked_at": "2023-10-05T07:38:51+02:00",
-    "highest_severity": 5
+    "highest_severity": 4,
+    "hits_by_severity": {
+          "1": 0,
+          "2": 1,
+          "3": 0,
+          "4": 1
+    }
   },
   "recommendations": [
     {


### PR DESCRIPTION
# Description
- fixes `highest_severity` field in DVO endpoints -- severity (total risk) can only be 1-4
- add `hits_by_severity` as per discussion with Frontend team

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps
locally

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
