### PR TITLE
[CCXDEV-16244] Add Codecov integration with unit-tests flag

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -20,6 +20,12 @@ jobs:
         run: go test -coverprofile coverage.out $(go list ./... | grep -v tests)
       - name: Display code coverage
         run: go tool cover -func=coverage.out
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          fail_ci_if_error: false
       - name: REST API tests setup
         run: ./run_on_ci.sh
       - name: Run REST API tests


### PR DESCRIPTION
# Description

- Add `codecov/codecov-action@v5` upload step after unit test coverage generation
- Uses `CODECOV_TOKEN`, `flags: unit-tests`, `fail_ci_if_error: false`

Fixes CCXDEV-16244

## Type of change

- Configuration update